### PR TITLE
fix(homelab): accept dev snapshot deploy targets

### DIFF
--- a/.github/workflows/deploy-homelab-app.yml
+++ b/.github/workflows/deploy-homelab-app.yml
@@ -45,10 +45,19 @@ jobs:
               ;;
           esac
 
-          release_id='^deopjib-v[0-9]+\.[0-9]+\.[0-9]+$'
+          stable_release_id='^deopjib-v[0-9]+\.[0-9]+\.[0-9]+$'
+          dev_snapshot_id='^deopjib-v0\.0\.0-dev\.[0-9a-f]{7,40}$'
           source_sha='^[0-9a-f]{40}$'
 
-          if printf '%s' "$TARGET" | grep -Eq "$release_id"; then
+          if printf '%s' "$TARGET" | grep -Eq "$stable_release_id"; then
+            exit 0
+          fi
+
+          if printf '%s' "$TARGET" | grep -Eq "$dev_snapshot_id"; then
+            if [ "$CHANNEL" = prod ]; then
+              echo "::error::prod dispatch requires a stable release id target, not a dev snapshot" >&2
+              exit 1
+            fi
             exit 0
           fi
 
@@ -63,7 +72,7 @@ jobs:
           if [ "$CHANNEL" = prod ]; then
             echo "::error::prod target must be a Deopjib release id like deopjib-v0.0.1" >&2
           else
-            echo "::error::target must be a Deopjib release id like deopjib-v0.0.1 or a transitional full lowercase source SHA" >&2
+            echo "::error::target must be a Deopjib release id like deopjib-v0.0.1, a dev snapshot like deopjib-v0.0.0-dev.abcdef0, or a transitional full lowercase source SHA" >&2
           fi
           exit 1
         env:


### PR DESCRIPTION
## Summary

Allows the homelab deploy dispatch workflow to accept Deopjib dev snapshot targets such as `deopjib-v0.0.0-dev.abcdef0` for the dev channel, while keeping prod restricted to stable release identifiers.

## Changes

- Split target validation into stable release IDs, dev snapshot IDs, and transitional full source SHAs.
- Reject dev snapshot IDs for prod dispatch.
- Update the dev-channel validation error message to show the accepted dev snapshot shape.

## Verification

- Workflow YAML parse
- `git diff --check -- .github/workflows/deploy-homelab-app.yml`

## Post-Deploy Monitoring & Validation

Validation owner: homelab operator.

Validation window: first Deopjib dev dispatch using a `deopjib-v0.0.0-dev.<sha>` target.

Healthy signals:

- Dev workflow validation accepts `deopjib-v0.0.0-dev.abcdef0` and reaches the deploy step.
- Prod workflow validation rejects that same dev snapshot shape before invoking `homelab-appctl`.

Failure signals and rollback/mitigation trigger:

- If dev snapshot dispatch fails validation, inspect the target string and workflow validation logs before enabling app repo wiring.
- If prod accepts a dev snapshot target, disable prod environment approval and patch validation before using prod dispatch.