### PR TITLE
fix(homelab): restart app image pull units during deploy

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -21,5 +21,8 @@ jobs:
       - name: Evaluate Phoenix template flake outputs
         run: nix flake check ./templates/phoenix --all-systems --no-build --show-trace
 
+      - name: Check homelab deploy invariants
+        run: nix build .#checks.x86_64-linux.homelab-appctl-deploy-invariants --show-trace
+
       - name: Check root formatting
         run: nix build .#checks.x86_64-linux.formatting --show-trace

--- a/flake.nix
+++ b/flake.nix
@@ -143,6 +143,23 @@
         };
 
       treefmtEval = eachSystem (system: treefmt-nix.lib.evalModule (pkgsFor system) treefmtModule);
+
+      homelabAppctlDeployInvariants =
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        pkgs.runCommand "homelab-appctl-deploy-invariants" { } ''
+          app_containers=${./systems/homelab/app-containers.nix}
+
+          ${pkgs.gnugrep}/bin/grep -F 'systemctl restart "$image_unit"' "$app_containers" >/dev/null
+          if ${pkgs.gnugrep}/bin/grep -F 'systemctl start "$image_unit"' "$app_containers" >/dev/null; then
+            echo 'homelab-appctl deploy must restart image pull units; start is a no-op for active oneshot .image units' >&2
+            exit 1
+          fi
+
+          touch "$out"
+        '';
     in
     {
       _debug = { };
@@ -151,6 +168,7 @@
 
       checks = eachSystem (system: {
         formatting = treefmtEval.${system}.config.build.check self;
+        homelab-appctl-deploy-invariants = homelabAppctlDeployInvariants system;
       });
 
       darwinConfigurations = lib.mapAttrs (

--- a/systems/homelab/app-containers.nix
+++ b/systems/homelab/app-containers.nix
@@ -705,7 +705,7 @@ let
 
         while IFS= read -r image_unit; do
           echo "pull: $image_unit"
-          if ! systemctl start "$image_unit"; then
+          if ! systemctl restart "$image_unit"; then
             finish_record "$record_dir" "$record_path" "$app" "$channel" "$target" pull-failed "$migration_result" "$smoke_result"
             return 1
           fi


### PR DESCRIPTION
## Summary
- restart app image pull units during `homelab-appctl deploy`
- fix stale `dev-current` deployments where Quadlet `.image` units stay `active (exited)` and `systemctl start` becomes a no-op
- add a CI-backed homelab deploy invariant check so image pull units cannot regress back to `systemctl start "$image_unit"`
- document the related homelab runner incident in `docs/solutions/` while the context is fresh

## Verification
- `nix fmt -- flake.nix`
- `git diff --check -- .github/workflows/nix.yml flake.nix systems/homelab/app-containers.nix docs/solutions/integration-issues/homelab-github-actions-runner-queued-deploy-2026-05-06.md`
- `nix flake check --all-systems --no-build --show-trace`
- `nix build .#checks.aarch64-darwin.homelab-appctl-deploy-invariants --show-trace`
- `nix build .#checks.aarch64-darwin.formatting --show-trace`
- frontmatter parser-safety check via Python stdlib because `scripts/validate-frontmatter.py` is not present in this repo

Note: local macOS cannot build `.#checks.x86_64-linux.homelab-appctl-deploy-invariants`; CI runs that exact Linux check.

## Runtime Evidence
- `deopjib-dev-backend-image.service` last pulled on 2026-04-29 and stayed `active (exited)`
- GHCR `deopjib-backend:dev-current` contains the fixed BEAM code, but homelab kept running the old local image config `708e417...` because the image unit was not restarted

## Regression Guard
- CI now builds `.#checks.x86_64-linux.homelab-appctl-deploy-invariants`
- the check fails if `homelab-appctl deploy` no longer contains `systemctl restart "$image_unit"`
- the check also fails if the old `systemctl start "$image_unit"` pattern returns
