### PR TITLE
[codex] Use github backend for Expert

### DIFF
--- a/files/workspace/.config/mise/config.toml
+++ b/files/workspace/.config/mise/config.toml
@@ -67,7 +67,7 @@ version = "latest"
 version = "latest"
 components = "rust-analyzer,rust-src"
 
-[tools.expert]
+[tools."github:expert-lsp/expert"]
 version = "latest"
 
 [tools.elixir-ls]


### PR DESCRIPTION
## Summary

- Change the workspace mise Expert tool declaration from the `expert` shorthand to `github:expert-lsp/expert`.
- Avoid the registry priority path that resolves the shorthand through `aqua:expert-lsp/expert`.

## Why

The shorthand declaration made mise resolve Expert through the aqua backend, which could emit registry lookup warnings while listing bin paths. The github backend resolves the same Expert release directly and keeps the `expert` binary available.

## Validation

- `mise ls --current`
- `mise bin-paths`
- `mise which expert`
- `mise exec -- expert --version`
- `just build_hj-workspace`
- `just check`