### PR TITLE
fix(homelab): register app service DNS aliases

### DIFF
--- a/systems/homelab/app-containers.nix
+++ b/systems/homelab/app-containers.nix
@@ -252,6 +252,7 @@ let
         LogDriver=journald
         EnvironmentFile=${envTemplate}
         Network=${unitPrefix}.network
+        NetworkAlias=${unitPrefix}-${serviceName}
         PublishPort=127.0.0.1:${toString servicePorts.${serviceName}}:${toString service.internalPort}
         ${concatLines volumeLines}
 
@@ -964,6 +965,12 @@ let
           {
             assertion = builtins.elem service.image imageNames;
             message = "homelab.apps.${appName}.${serviceName}: service.image must reference contract.images.";
+          }
+          {
+            assertion = lib.hasInfix "NetworkAlias=${unitPrefixFor app}-${serviceName}" (
+              (containerUnitFor app serviceName service).value.text
+            );
+            message = "homelab.apps.${appName}.${serviceName}: generated container must declare its network DNS alias.";
           }
         ]
         ++ map (envName: {


### PR DESCRIPTION
## 문제

Deopjib backend가 dev Podman network에서 deopjib-dev-db를 해석하지 못해 RPC가 unknown_error로 실패했습니다.

## 변경

- 모든 app service Quadlet에 안정적인 NetworkAlias를 생성합니다.
- 생성 결과에 별칭이 반드시 포함되도록 NixOS assertion을 추가합니다.

## 검증

- nix fmt systems/homelab/app-containers.nix
- nix eval --raw .#nixosConfigurations.homelab_hj.config.system.build.toplevel.drvPath
- nix flake check --all-systems --no-build --show-trace
- deopjib dev db/backend/web Quadlet의 ContainerName, Network, NetworkAlias 출력 확인