### PR TITLE
fix(homelab): recreate deopjib dev network

### DIFF
--- a/systems/homelab/app-admissions.nix
+++ b/systems/homelab/app-admissions.nix
@@ -1,7 +1,11 @@
-{ inputs, ... }:
+{ inputs, lib, ... }:
 let
   deopjibAdmission = import "${inputs.deopjibRuntime}/deopjib/devops/homelab-admission.nix";
 in
 {
-  homelab.apps.${deopjibAdmission.key} = deopjibAdmission.app;
+  # The original April network cannot be updated in place; a new name forces
+  # Podman to create clean netavark and aardvark state without touching volumes.
+  homelab.apps.${deopjibAdmission.key} = lib.recursiveUpdate deopjibAdmission.app {
+    host.networkName = "deopjib-dev-v2";
+  };
 }

--- a/systems/homelab/app-containers.nix
+++ b/systems/homelab/app-containers.nix
@@ -47,6 +47,9 @@ let
 
   unitPrefixFor = app: "${app.contract.name}-${app.contract.channel}";
 
+  networkNameFor =
+    app: if app.host.networkName == null then unitPrefixFor app else app.host.networkName;
+
   caddyPortFor =
     app: if app.host.caddyPort == null then app.host.loopbackPortBase - 1 else app.host.caddyPort;
 
@@ -252,7 +255,6 @@ let
         LogDriver=journald
         EnvironmentFile=${envTemplate}
         Network=${unitPrefix}.network
-        NetworkAlias=${unitPrefix}-${serviceName}
         PublishPort=127.0.0.1:${toString servicePorts.${serviceName}}:${toString service.internalPort}
         ${concatLines volumeLines}
 
@@ -275,7 +277,7 @@ let
     nameValuePair "containers/systemd/${unitPrefix}.network" {
       text = ''
         [Network]
-        NetworkName=${unitPrefix}
+        NetworkName=${networkNameFor app}
       '';
     };
 
@@ -288,6 +290,7 @@ let
       service = contract.services.${migrationServiceName};
       envTemplate = config.sops.templates.${envTemplateNameFor app migrationServiceName}.path;
       imageRef = imageRefFor app service;
+      networkName = networkNameFor app;
       networkService = "${unitPrefix}-network.service";
       imageService = "${unitPrefix}-${migrationServiceName}-image.service";
       volumeServices = map (mount: "${unitPrefix}-${mount.volume}-volume.service") service.volumeMounts;
@@ -314,7 +317,7 @@ let
       serviceConfig.Type = "oneshot";
       script = ''
         ${pkgs.podman}/bin/podman rm -f ${lib.escapeShellArg "${unitPrefix}-migrate"} >/dev/null 2>&1 || true
-        exec ${pkgs.podman}/bin/podman run --rm --pull=never --name ${lib.escapeShellArg "${unitPrefix}-migrate"} --env-file ${lib.escapeShellArg envTemplate} --network ${lib.escapeShellArg unitPrefix} ${volumeArgs} ${lib.escapeShellArg imageRef} ${lib.escapeShellArgs contract.migrations.command}
+        exec ${pkgs.podman}/bin/podman run --rm --pull=never --name ${lib.escapeShellArg "${unitPrefix}-migrate"} --env-file ${lib.escapeShellArg envTemplate} --network ${lib.escapeShellArg networkName} ${volumeArgs} ${lib.escapeShellArg imageRef} ${lib.escapeShellArgs contract.migrations.command}
       '';
     };
 
@@ -966,12 +969,6 @@ let
             assertion = builtins.elem service.image imageNames;
             message = "homelab.apps.${appName}.${serviceName}: service.image must reference contract.images.";
           }
-          {
-            assertion = lib.hasInfix "NetworkAlias=${unitPrefixFor app}-${serviceName}" (
-              (containerUnitFor app serviceName service).value.text
-            );
-            message = "homelab.apps.${appName}.${serviceName}: generated container must declare its network DNS alias.";
-          }
         ]
         ++ map (envName: {
           assertion = builtins.hasAttr envName app.host.secretMap;
@@ -1173,6 +1170,11 @@ in
               caddyPort = mkOption {
                 type = types.nullOr types.port;
                 default = null;
+              };
+              networkName = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                description = "Host-owned Podman network name override used for network generation changes.";
               };
               registryAuth = mkOption {
                 type = types.nullOr types.str;


### PR DESCRIPTION
## 근거

- 기존 deopjib-dev network는 2026-04-29에 생성된 장기 상태입니다.
- aardvark는 host 질의에는 DB A record를 반환하지만 backend와 migration 컨테이너에서는 계속 NXDOMAIN입니다.
- Podman은 같은 이름의 기존 network를 새 파라미터로 갱신하지 않습니다.

## 변경

- host runtime에 networkName override를 추가합니다.
- Deopjib dev를 deopjib-dev-v2 network로 옮겨 netavark/aardvark 상태를 새로 생성합니다.
- migration도 같은 실제 network 이름을 사용합니다.
- container name과 동일해 DNS record를 중복 생성하던 NetworkAlias를 제거합니다.

DB volume과 image/release contract는 변경하지 않으며 이전 network는 rollback을 위해 남깁니다.

## 검증

- RED: networkName option 부재로 NixOS 평가 실패
- GREEN: homelab_hj system 평가 통과
- generated NetworkName=deopjib-dev-v2 확인
- migration --network deopjib-dev-v2 확인
- nix flake check --all-systems --no-build --show-trace 통과