### PR TITLE
fix(homelab): couple app network to Podman lifecycle

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -21,5 +21,8 @@ jobs:
       - name: Check homelab deploy invariants
         run: nix build .#checks.x86_64-linux.homelab-appctl-deploy-invariants --show-trace
 
+      - name: Check homelab Quadlet lifecycle
+        run: nix build .#checks.x86_64-linux.homelab-quadlet-lifecycle-invariants --show-trace
+
       - name: Check root formatting
         run: nix build .#checks.x86_64-linux.formatting --show-trace

--- a/flake.lock
+++ b/flake.lock
@@ -145,6 +145,21 @@
         "type": "github"
       }
     },
+    "quadlet-nix": {
+      "locked": {
+        "lastModified": 1782004439,
+        "narHash": "sha256-OANOcPKJ3JThp2x/ccz4DDrGDY2hIgM5SBLI51swgfI=",
+        "owner": "SEIAROTg",
+        "repo": "quadlet-nix",
+        "rev": "f1652b490b812c4e0b2a36565cdbedf87f35e438",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SEIAROTg",
+        "repo": "quadlet-nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "comin": "comin",
@@ -153,6 +168,7 @@
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs_2",
         "nixpkgsPwgen": "nixpkgsPwgen",
+        "quadlet-nix": "quadlet-nix",
         "sops-nix": "sops-nix",
         "treefmt-nix": "treefmt-nix_2"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,8 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    quadlet-nix.url = "github:SEIAROTg/quadlet-nix";
+
     deopjibRuntime = {
       url = "github:rjcnd105/my-app/feat/deopjib-runtime-contract";
       flake = false;
@@ -45,6 +47,7 @@
       darwin,
       sops-nix,
       comin,
+      quadlet-nix,
       deopjibRuntime,
     }:
     let
@@ -159,6 +162,54 @@
           fi
 
           touch "$out"
+        '';
+
+      homelabQuadletLifecycleInvariants =
+        let
+          homelab = self.nixosConfigurations.homelab_hj.config;
+          quadlet = homelab.virtualisation.quadlet;
+          network = homelab.virtualisation.quadlet.networks.deopjib-dev;
+          networkService = "deopjib-dev-network.service";
+          podman = homelab.virtualisation.podman.package;
+          pkgs = pkgsFor "x86_64-linux";
+          networkText = builtins.unsafeDiscardStringContext network._configText;
+          podmanPath = builtins.unsafeDiscardStringContext "${podman}";
+          deopjibObjects = [
+            network
+          ]
+          ++ builtins.attrValues (
+            lib.filterAttrs (name: _: lib.hasPrefix "deopjib-dev-" name) quadlet.volumes
+          )
+          ++ builtins.attrValues (lib.filterAttrs (name: _: lib.hasPrefix "deopjib-dev-" name) quadlet.images)
+          ++ builtins.attrValues (
+            lib.filterAttrs (name: _: lib.hasPrefix "deopjib-dev-" name) quadlet.containers
+          );
+          quadletSources = pkgs.linkFarm "deopjib-dev-quadlets" (
+            map (object: {
+              name = object.ref;
+              path = pkgs.writeText object.ref object._configText;
+            }) deopjibObjects
+          );
+        in
+        assert network.networkConfig.name == "deopjib-dev";
+        assert builtins.all (container: builtins.elem networkService container.unitConfig.PartOf) (
+          builtins.attrValues (
+            lib.filterAttrs (name: _: lib.hasPrefix "deopjib-dev-" name) quadlet.containers
+          )
+        );
+        assert lib.hasInfix "${podmanPath}/bin/podman network rm deopjib-dev" networkText;
+        assert !(homelab.system.activationScripts ? homelabAppContainersRefresh);
+        pkgs.runCommand "homelab-quadlet-lifecycle-invariants" { } ''
+          export QUADLET_UNIT_DIRS=${quadletSources}
+          ${podman}/libexec/podman/quadlet -dryrun -no-kmsg-log > generated-units.txt
+
+          ${pkgs.gnugrep}/bin/grep -F 'PartOf=${networkService}' generated-units.txt >/dev/null
+          ${pkgs.gnugrep}/bin/grep -F 'Requires=${networkService}' generated-units.txt >/dev/null
+          ${pkgs.gnugrep}/bin/grep -F 'After=${networkService}' generated-units.txt >/dev/null
+          ${pkgs.gnugrep}/bin/grep -F 'ExecStop=${podman}/bin/podman network rm deopjib-dev' generated-units.txt >/dev/null
+
+          mkdir -p "$out"
+          cp generated-units.txt "$out/"
         '';
 
       homelabHindsightRuntimeInvariants =
@@ -304,7 +355,9 @@
             homelab-thermal-alert-smoke = homelabThermalAlertSmoke system;
           });
         in
-        baseChecks;
+        lib.recursiveUpdate baseChecks {
+          x86_64-linux.homelab-quadlet-lifecycle-invariants = homelabQuadletLifecycleInvariants;
+        };
 
       darwinConfigurations = lib.mapAttrs (
         key: config:
@@ -347,6 +400,7 @@
             home-manager.nixosModules.home-manager
             { home-manager.users.${userName}.imports = homeModulePaths; }
             comin.nixosModules.comin
+            quadlet-nix.nixosModules.quadlet
           ]
           ++ systemModulePaths;
         }

--- a/systems/homelab/app-containers.nix
+++ b/systems/homelab/app-containers.nix
@@ -178,36 +178,35 @@ let
     }
   ) enabledApps;
 
-  imageUnitFor =
+  quadletImageFor =
     app: serviceName: service:
     let
       authFile = registryAuthFileFor app;
       unitPrefix = unitPrefixFor app;
     in
-    nameValuePair "containers/systemd/${unitPrefix}-${serviceName}.image" {
-      text = ''
-        [Unit]
-        Description=Pull ${unitPrefix}-${serviceName} image
-        ${optionalString (authFile != null) "Requires=sops-install-secrets.service"}
-        After=network-online.target${optionalString (authFile != null) " sops-install-secrets.service"}
-        Wants=network-online.target
-
-        [Image]
-        Image=${imageRefFor app service}
-        ${optionalString (authFile != null) "AuthFile=${authFile}"}
-      '';
+    nameValuePair "${unitPrefix}-${serviceName}" {
+      autoStart = false;
+      unitConfig = {
+        Description = "Pull ${unitPrefix}-${serviceName} image";
+        After = lib.optional (authFile != null) "sops-install-secrets.service";
+      }
+      // lib.optionalAttrs (authFile != null) {
+        Requires = [ "sops-install-secrets.service" ];
+      };
+      imageConfig = {
+        image = imageRefFor app service;
+        authFile = authFile;
+      };
     };
 
-  volumeUnitFor =
+  quadletVolumeFor =
     app: volumeName: _volume:
     let
       unitPrefix = unitPrefixFor app;
     in
-    nameValuePair "containers/systemd/${unitPrefix}-${volumeName}.volume" {
-      text = ''
-        [Volume]
-        VolumeName=${unitPrefix}-${volumeName}
-      '';
+    nameValuePair "${unitPrefix}-${volumeName}" {
+      autoStart = false;
+      volumeConfig.name = "${unitPrefix}-${volumeName}";
     };
 
   mountLineFor =
@@ -218,7 +217,7 @@ let
     app: mount:
     "${unitPrefixFor app}-${mount.volume}:${mount.mountPath}${optionalString mount.readOnly ":ro"}";
 
-  containerUnitFor =
+  quadletContainerFor =
     app: serviceName: service:
     let
       unitPrefix = unitPrefixFor app;
@@ -226,57 +225,48 @@ let
       authFile = registryAuthFileFor app;
       envTemplate = config.sops.templates.${envTemplateNameFor app serviceName}.path;
       networkService = "${unitPrefix}-network.service";
-      volumeServices = map (mount: "${unitPrefix}-${mount.volume}-volume.service") service.volumeMounts;
-      volumeLines = map (mount: "Volume=${mountLineFor app mount}") service.volumeMounts;
+      volumes = map (mount: mountLineFor app mount) service.volumeMounts;
     in
-    nameValuePair "containers/systemd/${unitPrefix}-${serviceName}.container" {
-      text = ''
-        [Unit]
-        Description=${app.contract.name} ${app.contract.channel} ${serviceName} container
-        Requires=sops-install-secrets.service ${networkService} ${unitPrefix}-${serviceName}-image.service${
-          optionalString (volumeServices != [ ]) " ${concatStringsSep " " volumeServices}"
-        }
-        After=sops-install-secrets.service network-online.target ${networkService} ${unitPrefix}-${serviceName}-image.service${
-          optionalString (volumeServices != [ ]) " ${concatStringsSep " " volumeServices}"
-        }
-        Wants=network-online.target
-
-        [Container]
-        ContainerName=${unitPrefix}-${serviceName}
-        Image=${imageRefFor app service}
-        Pull=never
-        ${optionalString (service.updatePolicy == "registry-auto") "AutoUpdate=registry"}
-        ${optionalString (
-          service.updatePolicy == "registry-auto" && authFile != null
-        ) "Label=io.containers.autoupdate.authfile=${authFile}"}
-        LogDriver=journald
-        EnvironmentFile=${envTemplate}
-        Network=${unitPrefix}.network
-        NetworkAlias=${unitPrefix}-${serviceName}
-        PublishPort=127.0.0.1:${toString servicePorts.${serviceName}}:${toString service.internalPort}
-        ${concatLines volumeLines}
-
-        [Service]
-        Restart=on-failure
-        RestartSec=5s
-        TimeoutStartSec=${app.host.timeoutStartSec}
-        TimeoutStopSec=120
-
-        [Install]
-        WantedBy=multi-user.target
-      '';
+    nameValuePair "${unitPrefix}-${serviceName}" {
+      unitConfig = {
+        Description = "${app.contract.name} ${app.contract.channel} ${serviceName} container";
+        Requires = [ "sops-install-secrets.service" ];
+        After = [ "sops-install-secrets.service" ];
+        PartOf = [ networkService ];
+      };
+      containerConfig = {
+        name = "${unitPrefix}-${serviceName}";
+        image = "${unitPrefix}-${serviceName}.image";
+        pull = "never";
+        autoUpdate = if service.updatePolicy == "registry-auto" then "registry" else null;
+        labels = lib.optionalAttrs (service.updatePolicy == "registry-auto" && authFile != null) {
+          "io.containers.autoupdate.authfile" = authFile;
+        };
+        logDriver = "journald";
+        environmentFiles = [ envTemplate ];
+        networks = [ "${unitPrefix}.network" ];
+        networkAliases = [ "${unitPrefix}-${serviceName}" ];
+        publishPorts = [
+          "127.0.0.1:${toString servicePorts.${serviceName}}:${toString service.internalPort}"
+        ];
+        inherit volumes;
+      };
+      serviceConfig = {
+        Restart = "on-failure";
+        RestartSec = "5s";
+        TimeoutStartSec = app.host.timeoutStartSec;
+        TimeoutStopSec = 120;
+      };
     };
 
-  networkUnitFor =
+  quadletNetworkFor =
     app:
     let
       unitPrefix = unitPrefixFor app;
     in
-    nameValuePair "containers/systemd/${unitPrefix}.network" {
-      text = ''
-        [Network]
-        NetworkName=${unitPrefix}
-      '';
+    nameValuePair unitPrefix {
+      autoStart = false;
+      networkConfig.name = unitPrefix;
     };
 
   migrationServiceFor =
@@ -394,17 +384,29 @@ let
       text = builtins.toJSON (appMetadataFor appName app) + "\n";
     };
 
-  appEtc =
-    appName: app:
-    [
-      (networkUnitFor app)
-      (metadataEtcFor appName app)
-    ]
-    ++ mapAttrsToList (volumeUnitFor app) app.contract.volumes
-    ++ mapAttrsToList (imageUnitFor app) app.contract.services
-    ++ mapAttrsToList (containerUnitFor app) app.contract.services;
-
-  etcEntries = listToAttrs (flatten (mapAttrsToList appEtc enabledApps));
+  metadataEtcEntries = listToAttrs (mapAttrsToList metadataEtcFor enabledApps);
+  quadletNetworks = listToAttrs (mapAttrsToList (_appName: app: quadletNetworkFor app) enabledApps);
+  quadletVolumes = listToAttrs (
+    flatten (
+      mapAttrsToList (
+        _appName: app: mapAttrsToList (quadletVolumeFor app) app.contract.volumes
+      ) enabledApps
+    )
+  );
+  quadletImages = listToAttrs (
+    flatten (
+      mapAttrsToList (
+        _appName: app: mapAttrsToList (quadletImageFor app) app.contract.services
+      ) enabledApps
+    )
+  );
+  quadletContainers = listToAttrs (
+    flatten (
+      mapAttrsToList (
+        _appName: app: mapAttrsToList (quadletContainerFor app) app.contract.services
+      ) enabledApps
+    )
+  );
 
   homelabAppctl = pkgs.writeShellApplication {
     name = "homelab-appctl";
@@ -826,56 +828,6 @@ let
     '';
   };
 
-  appServiceNames =
-    app:
-    let
-      unitPrefix = unitPrefixFor app;
-    in
-    map (serviceName: "${unitPrefix}-${serviceName}.service") (
-      builtins.attrNames app.contract.services
-    );
-
-  activationApps = mapAttrsToList (
-    _appName: app:
-    let
-      unitPrefix = unitPrefixFor app;
-      services = concatStringsSep " " (appServiceNames app);
-    in
-    ''
-      app_prefix=${unitPrefix}
-      state_dir=/var/lib/homelab-app-containers
-      marker=$state_dir/$app_prefix.sha256
-
-      if ${pkgs.coreutils}/bin/ls /etc/containers/systemd/$app_prefix* >/dev/null 2>&1; then
-        mkdir -p "$state_dir"
-        new_hash="$(
-          for file in /etc/containers/systemd/$app_prefix*; do
-            [ -e "$file" ] && ${pkgs.coreutils}/bin/sha256sum "$file"
-          done | ${pkgs.coreutils}/bin/sha256sum | ${pkgs.coreutils}/bin/cut -d ' ' -f1
-        )"
-        old_hash="$(${pkgs.coreutils}/bin/cat "$marker" 2>/dev/null || true)"
-
-        if [ "$new_hash" != "$old_hash" ]; then
-          ${pkgs.systemd}/bin/systemctl daemon-reload || true
-          ok=1
-          for service in ${services}; do
-            if ${pkgs.systemd}/bin/systemctl is-active --quiet "$service"; then
-              ${pkgs.systemd}/bin/systemctl restart "$service" || ok=0
-            else
-              ${pkgs.systemd}/bin/systemctl start "$service" || ok=0
-            fi
-          done
-
-          if [ "$ok" = 1 ]; then
-            printf '%s\n' "$new_hash" > "$marker"
-          else
-            echo "warning: failed to start or restart services for $app_prefix" >&2
-          fi
-        fi
-      fi
-    ''
-  ) enabledApps;
-
   assertionsForApp =
     appName: app:
     let
@@ -967,8 +919,8 @@ let
             message = "homelab.apps.${appName}.${serviceName}: service.image must reference contract.images.";
           }
           {
-            assertion = lib.hasInfix "NetworkAlias=${unitPrefixFor app}-${serviceName}" (
-              (containerUnitFor app serviceName service).value.text
+            assertion = builtins.elem "${unitPrefixFor app}-${serviceName}" (
+              (quadletContainerFor app serviceName service).value.containerConfig.networkAliases
             );
             message = "homelab.apps.${appName}.${serviceName}: generated container must declare its network DNS alias.";
           }
@@ -1241,7 +1193,14 @@ in
 
     services.cloudflared.tunnels.${cloudflareTunnelId}.ingress = appIngress;
 
-    environment.etc = etcEntries;
+    virtualisation.quadlet = {
+      networks = quadletNetworks;
+      volumes = quadletVolumes;
+      images = quadletImages;
+      containers = quadletContainers;
+    };
+
+    environment.etc = metadataEtcEntries;
     environment.systemPackages = [ homelabAppctl ];
 
     security.sudo.extraRules = [
@@ -1272,13 +1231,5 @@ in
     systemd.tmpfiles.rules = [
       "d /var/lib/homelab-appctl 0750 root root - -"
     ];
-
-    system.activationScripts.homelabAppContainersRefresh = {
-      deps = [
-        "etc"
-        "specialfs"
-      ];
-      text = concatLines activationApps;
-    };
   };
 }


### PR DESCRIPTION
## Why

After NixOS moved Podman from 5.8.3 to 5.8.4, the long-lived Aardvark process still referenced the deleted 5.8.3 store path. Deopjib container IP/TCP worked, but `deopjib-dev-db` resolved as NXDOMAIN. The hand-written Quadlets and activation hash restarted containers without making the Podman-backed network part of the same lifecycle.

## What

- pin `quadlet-nix` at `f1652b490b812c4e0b2a36565cdbedf87f35e438`
- render admitted app networks, images, volumes, and containers through typed Quadlet options
- make every app container `PartOf` its network service while typed references generate `Requires` and `After` ordering
- remove the custom `homelabAppContainersRefresh` activation shell
- add a Linux flake/CI invariant that runs Podman's real Quadlet generator and checks the network lifecycle

The network unit embeds the active Podman store path in `ExecStop`. A Podman package change therefore changes the unit hash, restarts the network, stops its containers first, and recreates DNS state with the current Netavark/Aardvark binaries.

## Validation

- `nix fmt`
- `nix flake check --all-systems --no-build --show-trace`
- x86_64 Linux build of `homelab-quadlet-lifecycle-invariants` on homelab from this bookmark
- Podman 5.8.4 generator accepted all eight Deopjib Quadlets and emitted image, network, and DB-volume dependencies
- generated app metadata remained unchanged

## Rollout

Merge through the normal GitOps/comin path, then verify the Aardvark executable store path, internal DNS, DB connectivity, Deopjib RPC, public ingress, and Hindsight.