### PR TITLE
fix(homelab): restart app network with Podman package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -170,6 +170,7 @@
           quadlet = homelab.virtualisation.quadlet;
           network = homelab.virtualisation.quadlet.networks.deopjib-dev;
           networkService = "deopjib-dev-network.service";
+          networkUnit = homelab.systemd.services.deopjib-dev-network;
           podman = homelab.virtualisation.podman.package;
           pkgs = pkgsFor "x86_64-linux";
           networkText = builtins.unsafeDiscardStringContext network._configText;
@@ -198,6 +199,7 @@
           )
         );
         assert lib.hasInfix "${podmanPath}/bin/podman network rm deopjib-dev" networkText;
+        assert builtins.elem podman networkUnit.restartTriggers;
         assert !(homelab.system.activationScripts ? homelabAppContainersRefresh);
         pkgs.runCommand "homelab-quadlet-lifecycle-invariants" { } ''
           export QUADLET_UNIT_DIRS=${quadletSources}

--- a/systems/homelab/app-containers.nix
+++ b/systems/homelab/app-containers.nix
@@ -407,6 +407,12 @@ let
       ) enabledApps
     )
   );
+  networkLifecycleServices = mapAttrs' (
+    _appName: app:
+    nameValuePair "${unitPrefixFor app}-network" {
+      restartTriggers = [ config.virtualisation.podman.package ];
+    }
+  ) enabledApps;
 
   homelabAppctl = pkgs.writeShellApplication {
     name = "homelab-appctl";
@@ -1226,7 +1232,7 @@ in
       }
     ];
 
-    systemd.services = migrationServices;
+    systemd.services = migrationServices // networkLifecycleServices;
 
     systemd.tmpfiles.rules = [
       "d /var/lib/homelab-appctl 0750 root root - -"


### PR DESCRIPTION
## Why

PR #68 moved the app renderer to typed `quadlet-nix` resources and deployed successfully, but the first adoption did not restart the already-active `deopjib-dev-network.service`. Its `ActiveEnterTimestamp` remained 2026-04-29 and Aardvark still ran from the deleted Podman 5.8.3 store path. The new `PartOf`, `Requires`, and `After` relationships are loaded; the missing piece is an explicit NixOS restart trigger.

## What

Attach each admitted app network unit to `config.virtualisation.podman.package` through native `systemd.services.<network>.restartTriggers`. This emits NixOS `X-Restart-Triggers` metadata and makes both this transition and future Podman package path changes restart the network. The existing `PartOf` and generated ordering propagate the lifecycle to containers without a recovery script.

The lifecycle flake invariant now requires the Podman package in the network unit restart triggers.

## TDD and validation

- RED: the new assertion failed because `networkUnit.restartTriggers` was empty
- GREEN: the assertion and `nix flake check --all-systems --no-build --show-trace` pass
- built the complete x86_64 NixOS toplevel from this bookmark on homelab
- candidate unit contains `X-Restart-Triggers-deopjib-dev-network`

After merge, comin will switch the generation. Live acceptance is a new current-store Aardvark PID plus working Deopjib DNS, DB, RPC, ingress, and unchanged Hindsight.