### PR TITLE
fix(homelab): coordinate Podman DNS lifecycle globally

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -170,11 +170,19 @@
           quadlet = homelab.virtualisation.quadlet;
           network = homelab.virtualisation.quadlet.networks.deopjib-dev;
           networkService = "deopjib-dev-network.service";
-          networkUnit = homelab.systemd.services.deopjib-dev-network;
+          dnsLifecycleService = "podman-dns-lifecycle.service";
+          dnsLifecycleUnit = homelab.systemd.services.podman-dns-lifecycle;
+          hindsightUnits = [
+            homelab.systemd.services.hindsight-db
+            homelab.systemd.services.hindsight
+          ];
           podman = homelab.virtualisation.podman.package;
           pkgs = pkgsFor "x86_64-linux";
           networkText = builtins.unsafeDiscardStringContext network._configText;
           podmanPath = builtins.unsafeDiscardStringContext "${podman}";
+          deopjibContainers = builtins.attrValues (
+            lib.filterAttrs (name: _: lib.hasPrefix "deopjib-dev-" name) quadlet.containers
+          );
           deopjibObjects = [
             network
           ]
@@ -182,9 +190,7 @@
             lib.filterAttrs (name: _: lib.hasPrefix "deopjib-dev-" name) quadlet.volumes
           )
           ++ builtins.attrValues (lib.filterAttrs (name: _: lib.hasPrefix "deopjib-dev-" name) quadlet.images)
-          ++ builtins.attrValues (
-            lib.filterAttrs (name: _: lib.hasPrefix "deopjib-dev-" name) quadlet.containers
-          );
+          ++ deopjibContainers;
           quadletSources = pkgs.linkFarm "deopjib-dev-quadlets" (
             map (object: {
               name = object.ref;
@@ -193,19 +199,24 @@
           );
         in
         assert network.networkConfig.name == "deopjib-dev";
-        assert builtins.all (container: builtins.elem networkService container.unitConfig.PartOf) (
-          builtins.attrValues (
-            lib.filterAttrs (name: _: lib.hasPrefix "deopjib-dev-" name) quadlet.containers
-          )
-        );
+        assert builtins.all (
+          container:
+          builtins.elem networkService container.unitConfig.PartOf
+          && builtins.elem dnsLifecycleService container.unitConfig.PartOf
+        ) deopjibContainers;
+        assert builtins.elem dnsLifecycleService network.unitConfig.PartOf;
         assert lib.hasInfix "${podmanPath}/bin/podman network rm deopjib-dev" networkText;
-        assert builtins.elem podman networkUnit.restartTriggers;
+        assert builtins.elem podman dnsLifecycleUnit.restartTriggers;
+        assert builtins.all (
+          unit: unit.overrideStrategy == "asDropin" && builtins.elem dnsLifecycleService unit.partOf
+        ) hindsightUnits;
         assert !(homelab.system.activationScripts ? homelabAppContainersRefresh);
         pkgs.runCommand "homelab-quadlet-lifecycle-invariants" { } ''
           export QUADLET_UNIT_DIRS=${quadletSources}
           ${podman}/libexec/podman/quadlet -dryrun -no-kmsg-log > generated-units.txt
 
           ${pkgs.gnugrep}/bin/grep -F 'PartOf=${networkService}' generated-units.txt >/dev/null
+          ${pkgs.gnugrep}/bin/grep -F '${dnsLifecycleService}' generated-units.txt >/dev/null
           ${pkgs.gnugrep}/bin/grep -F 'Requires=${networkService}' generated-units.txt >/dev/null
           ${pkgs.gnugrep}/bin/grep -F 'After=${networkService}' generated-units.txt >/dev/null
           ${pkgs.gnugrep}/bin/grep -F 'ExecStop=${podman}/bin/podman network rm deopjib-dev' generated-units.txt >/dev/null

--- a/systems/homelab/app-containers.nix
+++ b/systems/homelab/app-containers.nix
@@ -27,6 +27,7 @@ let
   enabledApps = filterAttrs (_: app: app.enable) cfg.apps;
   hasApps = enabledApps != { };
   cloudflareTunnelId = "a19003a7-293f-4872-b8a5-1db544878f45";
+  podmanDnsLifecycleService = "podman-dns-lifecycle.service";
 
   validId = value: builtins.match "^[a-z0-9][a-z0-9-]*$" value != null;
 
@@ -230,9 +231,18 @@ let
     nameValuePair "${unitPrefix}-${serviceName}" {
       unitConfig = {
         Description = "${app.contract.name} ${app.contract.channel} ${serviceName} container";
-        Requires = [ "sops-install-secrets.service" ];
-        After = [ "sops-install-secrets.service" ];
-        PartOf = [ networkService ];
+        Requires = [
+          "sops-install-secrets.service"
+          podmanDnsLifecycleService
+        ];
+        After = [
+          "sops-install-secrets.service"
+          podmanDnsLifecycleService
+        ];
+        PartOf = [
+          networkService
+          podmanDnsLifecycleService
+        ];
       };
       containerConfig = {
         name = "${unitPrefix}-${serviceName}";
@@ -266,6 +276,11 @@ let
     in
     nameValuePair unitPrefix {
       autoStart = false;
+      unitConfig = {
+        Requires = [ podmanDnsLifecycleService ];
+        After = [ podmanDnsLifecycleService ];
+        PartOf = [ podmanDnsLifecycleService ];
+      };
       networkConfig.name = unitPrefix;
     };
 
@@ -407,13 +422,6 @@ let
       ) enabledApps
     )
   );
-  networkLifecycleServices = mapAttrs' (
-    _appName: app:
-    nameValuePair "${unitPrefixFor app}-network" {
-      restartTriggers = [ config.virtualisation.podman.package ];
-    }
-  ) enabledApps;
-
   homelabAppctl = pkgs.writeShellApplication {
     name = "homelab-appctl";
     runtimeInputs = [
@@ -1232,7 +1240,7 @@ in
       }
     ];
 
-    systemd.services = migrationServices // networkLifecycleServices;
+    systemd.services = migrationServices;
 
     systemd.tmpfiles.rules = [
       "d /var/lib/homelab-appctl 0750 root root - -"

--- a/systems/homelab/default.nix
+++ b/systems/homelab/default.nix
@@ -1,4 +1,5 @@
 {
+  config,
   pkgs,
   ...
 }:
@@ -61,6 +62,19 @@
   };
 
   systemd.timers.podman-auto-update.wantedBy = [ "timers.target" ];
+
+  # Rootful Podman shares one Aardvark DNS process across bridge networks.
+  # Restart all DNS-backed workloads together so it cannot retain an old Podman store path.
+  systemd.services.podman-dns-lifecycle = {
+    description = "Coordinate Podman DNS-backed containers across runtime upgrades";
+    wantedBy = [ "multi-user.target" ];
+    restartTriggers = [ config.virtualisation.podman.package ];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.coreutils}/bin/true";
+      RemainAfterExit = true;
+    };
+  };
 
   # llama.cpp — CPU 모드로 시작. GPU 가속은 ROCm gfx1150 공식 지원 후 추가
   # 로컬 전용 바인딩. 외부 접근이 필요하면 host를 0.0.0.0으로 변경하고 firewall에 8080 추가

--- a/systems/homelab/hindsight-stack.nix
+++ b/systems/homelab/hindsight-stack.nix
@@ -17,6 +17,7 @@
 let
   servicesEnv = config.sops.templates."services.env".path;
   legacyDbVolumePath = "/var/lib/docker/volumes/hindsight-db-data/_data";
+  podmanDnsLifecycleService = "podman-dns-lifecycle.service";
 
   images = {
     # GHCR does not publish a semantic 0.8.4-slim tag; latest-slim's OCI
@@ -230,6 +231,21 @@ in
       [Install]
       WantedBy=multi-user.target
     '';
+  };
+
+  # Quadlet owns these generated units; NixOS contributes only lifecycle drop-ins.
+  systemd.services.hindsight-db = {
+    overrideStrategy = "asDropin";
+    requires = [ podmanDnsLifecycleService ];
+    after = [ podmanDnsLifecycleService ];
+    partOf = [ podmanDnsLifecycleService ];
+  };
+
+  systemd.services.hindsight = {
+    overrideStrategy = "asDropin";
+    requires = [ podmanDnsLifecycleService ];
+    after = [ podmanDnsLifecycleService ];
+    partOf = [ podmanDnsLifecycleService ];
   };
 
   systemd.services.hindsight-db-settings = {


### PR DESCRIPTION
## Summary
- add one NixOS-owned Podman DNS lifecycle service keyed by the Podman package derivation
- couple Deopjib Quadlet networks and containers through typed Unit dependencies
- attach Hindsight generated Quadlet services with the native NixOS asDropin strategy
- assert the global lifecycle and generated Quadlet dependencies in flake checks

## Root cause
Restarting only the Deopjib network did not replace Aardvark because hindsight-db remained attached to the rootful default bridge. Aardvark is shared across those bridge networks, so all DNS-backed workloads must stop together during a Podman package transition.

This supersedes the narrower lifecycle scopes from #68 and #69 without adding activation scripts or process-kill recovery.

## Validation
- nix fmt
- nix eval --raw .#checks.x86_64-linux.homelab-quadlet-lifecycle-invariants.drvPath --show-trace
- nix flake check --all-systems --no-build --show-trace
- x86_64 homelab build: homelab-quadlet-lifecycle-invariants
- x86_64 homelab build: nixosConfigurations.homelab_hj.config.system.build.toplevel

Remote outputs:
- /nix/store/n2dnb7m5b8257bcsi4kd0y7j98p3gdj4-homelab-quadlet-lifecycle-invariants
- /nix/store/r9v6f7yhv7i4irkaiid7yy8ljvxqvlnz-nixos-system-homelab-26.11.20260629.b5aa0fb