### PR TITLE
fix(homelab): restart Podman DNS on topology changes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -171,7 +171,16 @@
           network = homelab.virtualisation.quadlet.networks.deopjib-dev;
           networkService = "deopjib-dev-network.service";
           dnsLifecycleService = "podman-dns-lifecycle.service";
+          dnsLifecycleConfig = homelab.homelab.podmanDnsLifecycle;
           dnsLifecycleUnit = homelab.systemd.services.podman-dns-lifecycle;
+          expectedDnsLifecycleMembers = [
+            "deopjib-dev-backend.service"
+            "deopjib-dev-db.service"
+            "deopjib-dev-network.service"
+            "deopjib-dev-web.service"
+            "hindsight-db.service"
+            "hindsight.service"
+          ];
           hindsightUnits = [
             homelab.systemd.services.hindsight-db
             homelab.systemd.services.hindsight
@@ -206,7 +215,10 @@
         ) deopjibContainers;
         assert builtins.elem dnsLifecycleService network.unitConfig.PartOf;
         assert lib.hasInfix "${podmanPath}/bin/podman network rm deopjib-dev" networkText;
+        assert dnsLifecycleConfig.unit == dnsLifecycleService;
+        assert lib.sort builtins.lessThan dnsLifecycleConfig.members == expectedDnsLifecycleMembers;
         assert builtins.elem podman dnsLifecycleUnit.restartTriggers;
+        assert builtins.length dnsLifecycleUnit.restartTriggers == 2;
         assert builtins.all (
           unit: unit.overrideStrategy == "asDropin" && builtins.elem dnsLifecycleService unit.partOf
         ) hindsightUnits;

--- a/systems/homelab/app-containers.nix
+++ b/systems/homelab/app-containers.nix
@@ -27,7 +27,7 @@ let
   enabledApps = filterAttrs (_: app: app.enable) cfg.apps;
   hasApps = enabledApps != { };
   cloudflareTunnelId = "a19003a7-293f-4872-b8a5-1db544878f45";
-  podmanDnsLifecycleService = "podman-dns-lifecycle.service";
+  podmanDnsLifecycleService = cfg.podmanDnsLifecycle.unit;
 
   validId = value: builtins.match "^[a-z0-9][a-z0-9-]*$" value != null;
 
@@ -1213,6 +1213,10 @@ in
       images = quadletImages;
       containers = quadletContainers;
     };
+
+    homelab.podmanDnsLifecycle.members =
+      map (name: "${name}-network.service") (builtins.attrNames quadletNetworks)
+      ++ map (name: "${name}.service") (builtins.attrNames quadletContainers);
 
     environment.etc = metadataEtcEntries;
     environment.systemPackages = [ homelabAppctl ];

--- a/systems/homelab/default.nix
+++ b/systems/homelab/default.nix
@@ -1,8 +1,4 @@
-{
-  config,
-  pkgs,
-  ...
-}:
+{ pkgs, ... }:
 {
 
   imports = [
@@ -10,6 +6,7 @@
     ./sops.nix
     ./cloudflared.nix
     ./ai-stack.nix
+    ./podman-dns-lifecycle.nix
     ./hindsight-stack.nix
     ./app-containers.nix
     ./app-admissions.nix
@@ -62,19 +59,6 @@
   };
 
   systemd.timers.podman-auto-update.wantedBy = [ "timers.target" ];
-
-  # Rootful Podman shares one Aardvark DNS process across bridge networks.
-  # Restart all DNS-backed workloads together so it cannot retain an old Podman store path.
-  systemd.services.podman-dns-lifecycle = {
-    description = "Coordinate Podman DNS-backed containers across runtime upgrades";
-    wantedBy = [ "multi-user.target" ];
-    restartTriggers = [ config.virtualisation.podman.package ];
-    serviceConfig = {
-      Type = "oneshot";
-      ExecStart = "${pkgs.coreutils}/bin/true";
-      RemainAfterExit = true;
-    };
-  };
 
   # llama.cpp — CPU 모드로 시작. GPU 가속은 ROCm gfx1150 공식 지원 후 추가
   # 로컬 전용 바인딩. 외부 접근이 필요하면 host를 0.0.0.0으로 변경하고 firewall에 8080 추가

--- a/systems/homelab/hindsight-stack.nix
+++ b/systems/homelab/hindsight-stack.nix
@@ -17,7 +17,7 @@
 let
   servicesEnv = config.sops.templates."services.env".path;
   legacyDbVolumePath = "/var/lib/docker/volumes/hindsight-db-data/_data";
-  podmanDnsLifecycleService = "podman-dns-lifecycle.service";
+  podmanDnsLifecycleService = config.homelab.podmanDnsLifecycle.unit;
 
   images = {
     # GHCR does not publish a semantic 0.8.4-slim tag; latest-slim's OCI
@@ -50,6 +50,11 @@ let
   '';
 in
 {
+  homelab.podmanDnsLifecycle.members = [
+    "hindsight-db.service"
+    "hindsight.service"
+  ];
+
   system.activationScripts.hindsightDbVolumePath = ''
     mkdir -p ${legacyDbVolumePath}
   '';

--- a/systems/homelab/podman-dns-lifecycle.nix
+++ b/systems/homelab/podman-dns-lifecycle.nix
@@ -1,0 +1,64 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.homelab.podmanDnsLifecycle;
+  members = lib.sort builtins.lessThan (lib.unique cfg.members);
+  topology = builtins.toFile "podman-dns-lifecycle-members" (
+    lib.concatMapStrings (unit: "${unit}\n") members
+  );
+in
+{
+  options.homelab.podmanDnsLifecycle = {
+    unit = lib.mkOption {
+      type = lib.types.str;
+      default = "podman-dns-lifecycle.service";
+      readOnly = true;
+      internal = true;
+      description = "Systemd unit coordinating rootful Podman DNS workloads.";
+    };
+
+    members = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      internal = true;
+      description = "Systemd services sharing the rootful Podman Aardvark DNS process.";
+    };
+  };
+
+  config = lib.mkIf (cfg.members != [ ]) {
+    assertions = [
+      {
+        assertion = config.virtualisation.podman.enable;
+        message = "homelab.podmanDnsLifecycle requires virtualisation.podman.enable.";
+      }
+      {
+        assertion = builtins.length cfg.members == builtins.length members;
+        message = "homelab.podmanDnsLifecycle.members must have one owner per systemd unit.";
+      }
+      {
+        assertion = builtins.all (lib.hasSuffix ".service") cfg.members;
+        message = "homelab.podmanDnsLifecycle.members entries must be systemd service units.";
+      }
+    ];
+
+    # Rootful Podman shares one Aardvark process across bridge networks. The
+    # content-addressed topology trigger also handles first-time member adoption.
+    systemd.services.${lib.removeSuffix ".service" cfg.unit} = {
+      description = "Coordinate Podman DNS-backed containers across runtime upgrades";
+      wantedBy = [ "multi-user.target" ];
+      restartTriggers = [
+        config.virtualisation.podman.package
+        topology
+      ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.coreutils}/bin/true";
+        RemainAfterExit = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- add a dedicated podman-dns-lifecycle NixOS module that owns the coordinator and content-addressed topology trigger
- let app-containers and hindsight-stack register only the systemd units they own through an internal typed module option
- restart the global lifecycle when Podman changes or DNS member topology changes
- pin the exact expected member contract in the existing flake regression check

## Ownership
homelab/default.nix only imports the lifecycle module. It does not know Hindsight or Deopjib unit names. Each workload module contributes its own members, while the dedicated lifecycle module owns ordering, uniqueness validation, and trigger generation.

## Why
#70 installed the correct PartOf drop-ins, but existing Hindsight units were not restarted during their first introduction. The old Aardvark process therefore remained on the Podman 5.8.3 store path. A topology-derived trigger now restarts the already-active global lifecycle after those drop-ins are present, without a shell migration or manual process kill.

## Validation
- TDD red: lifecycle had one trigger instead of the required package plus topology triggers
- nix fmt
- nix flake check --all-systems --no-build --show-trace
- x86_64 homelab invariant and full NixOS toplevel builds
- GitHub Actions Nix check

Remote toplevel:
- /nix/store/gy5kp75lygnp8arcas5zxbxhw7csmfw7-nixos-system-homelab-26.11.20260629.b5aa0fb