### PR TITLE
fix(homelab): isolate Hindsight from Podman DNS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -168,6 +168,9 @@
         let
           homelab = self.nixosConfigurations.homelab_hj.config;
           quadlet = homelab.virtualisation.quadlet;
+          hindsightDbContainerText = homelab.environment.etc."containers/systemd/hindsight-db.container".text;
+          hindsightDbVolumeText = homelab.environment.etc."containers/systemd/hindsight-db-data.volume".text;
+          hindsightNetwork = quadlet.networks.hindsight-db;
           network = homelab.virtualisation.quadlet.networks.deopjib-dev;
           networkService = "deopjib-dev-network.service";
           dnsLifecycleService = "podman-dns-lifecycle.service";
@@ -178,6 +181,7 @@
             "deopjib-dev-db.service"
             "deopjib-dev-network.service"
             "deopjib-dev-web.service"
+            "hindsight-db-network.service"
             "hindsight-db.service"
             "hindsight.service"
           ];
@@ -192,19 +196,30 @@
           deopjibContainers = builtins.attrValues (
             lib.filterAttrs (name: _: lib.hasPrefix "deopjib-dev-" name) quadlet.containers
           );
-          deopjibObjects = [
+          quadletObjects = [
             network
+            hindsightNetwork
           ]
           ++ builtins.attrValues (
             lib.filterAttrs (name: _: lib.hasPrefix "deopjib-dev-" name) quadlet.volumes
           )
           ++ builtins.attrValues (lib.filterAttrs (name: _: lib.hasPrefix "deopjib-dev-" name) quadlet.images)
-          ++ deopjibContainers;
+          ++ deopjibContainers
+          ++ [
+            {
+              ref = "hindsight-db-data.volume";
+              _configText = hindsightDbVolumeText;
+            }
+            {
+              ref = "hindsight-db.container";
+              _configText = hindsightDbContainerText;
+            }
+          ];
           quadletSources = pkgs.linkFarm "deopjib-dev-quadlets" (
             map (object: {
               name = object.ref;
               path = pkgs.writeText object.ref object._configText;
-            }) deopjibObjects
+            }) quadletObjects
           );
         in
         assert network.networkConfig.name == "deopjib-dev";
@@ -214,6 +229,9 @@
           && builtins.elem dnsLifecycleService container.unitConfig.PartOf
         ) deopjibContainers;
         assert builtins.elem dnsLifecycleService network.unitConfig.PartOf;
+        assert hindsightNetwork.networkConfig.disableDns;
+        assert builtins.elem dnsLifecycleService hindsightNetwork.unitConfig.PartOf;
+        assert lib.hasInfix "Network=${hindsightNetwork.ref}" hindsightDbContainerText;
         assert lib.hasInfix "${podmanPath}/bin/podman network rm deopjib-dev" networkText;
         assert dnsLifecycleConfig.unit == dnsLifecycleService;
         assert lib.sort builtins.lessThan dnsLifecycleConfig.members == expectedDnsLifecycleMembers;
@@ -232,6 +250,8 @@
           ${pkgs.gnugrep}/bin/grep -F 'Requires=${networkService}' generated-units.txt >/dev/null
           ${pkgs.gnugrep}/bin/grep -F 'After=${networkService}' generated-units.txt >/dev/null
           ${pkgs.gnugrep}/bin/grep -F 'ExecStop=${podman}/bin/podman network rm deopjib-dev' generated-units.txt >/dev/null
+          ${pkgs.gnugrep}/bin/grep -F -- '--disable-dns hindsight-db' generated-units.txt >/dev/null
+          ${pkgs.gnugrep}/bin/grep -F 'Requires=hindsight-db-network.service' generated-units.txt >/dev/null
 
           mkdir -p "$out"
           cp generated-units.txt "$out/"

--- a/systems/homelab/hindsight-stack.nix
+++ b/systems/homelab/hindsight-stack.nix
@@ -51,9 +51,25 @@ let
 in
 {
   homelab.podmanDnsLifecycle.members = [
+    "hindsight-db-network.service"
     "hindsight-db.service"
     "hindsight.service"
   ];
+
+  # The API reaches Postgres through the host-published loopback port. Keeping
+  # this bridge off Aardvark prevents it from winning the app-DNS startup race.
+  virtualisation.quadlet.networks.hindsight-db = {
+    autoStart = false;
+    unitConfig = {
+      Requires = [ podmanDnsLifecycleService ];
+      After = [ podmanDnsLifecycleService ];
+      PartOf = [ podmanDnsLifecycleService ];
+    };
+    networkConfig = {
+      name = "hindsight-db";
+      disableDns = true;
+    };
+  };
 
   system.activationScripts.hindsightDbVolumePath = ''
     mkdir -p ${legacyDbVolumePath}
@@ -126,6 +142,7 @@ in
       Environment=POSTGRES_USER=hindsight
       Environment=POSTGRES_DB=hindsight
       Volume=hindsight-db-data.volume:/home/postgres/pgdata/data
+      Network=hindsight-db.network
       PublishPort=127.0.0.1:5432:5432
 
       [Service]

--- a/systems/homelab/podman-dns-lifecycle.nix
+++ b/systems/homelab/podman-dns-lifecycle.nix
@@ -25,7 +25,7 @@ in
       type = lib.types.listOf lib.types.str;
       default = [ ];
       internal = true;
-      description = "Systemd services sharing the rootful Podman Aardvark DNS process.";
+      description = "Systemd services coordinated around the rootful Podman Aardvark lifecycle.";
     };
   };
 


### PR DESCRIPTION
## Summary
- put Hindsight Postgres on a typed, DNS-disabled Quadlet network owned by hindsight-stack
- keep its published 127.0.0.1:5432 contract unchanged for the host-network Hindsight API
- register the network with the global Podman lifecycle so the migration is stop/start coordinated
- run the real Podman generator against the Hindsight network, volume, and DB container in CI

## Root cause
After #71, Aardvark was correctly replaced with Podman 5.8.4 and every container restarted. Deopjib still failed because Hindsight DB attached to the DNS-enabled default bridge first. Aardvark answered only on that bridge, while queries to the later Deopjib bridge timed out.

Runtime proof:
- deopjib-dev has dns_enabled=true and both aliases in Podman inspect
- backend resolver points to 10.89.0.1
- Aardvark is Podman 5.8.4 / aardvark-dns 2.0.0
- nslookup from deopjib-dev-web: no servers could be reached
- direct backend TCP to 10.89.0.3:5432 succeeds
- Hindsight health reports database connected

Hindsight does not require container DNS: its API uses host networking and reaches Postgres through the published loopback port. Its dedicated bridge therefore disables DNS declaratively with quadlet-nix instead of adding process-kill or restart scripts.

Related upstream behavior: containers/podman#20396 and containers/aardvark-dns#679.

## Validation
- TDD red: hindsight-db network missing
- nix fmt
- nix flake check --all-systems --no-build --show-trace
- x86_64 homelab Podman generator invariant build
- x86_64 homelab full NixOS toplevel build

Remote outputs:
- /nix/store/rlazjv6v36m14jqnix7y5cksjd45y23l-homelab-quadlet-lifecycle-invariants
- /nix/store/kspvgybk7psqs6a66j8hwryrm9v50q41-nixos-system-homelab-26.11.20260629.b5aa0fb