### PR TITLE
fix(homelab): allow DNS on app bridges

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -223,6 +223,8 @@
           );
         in
         assert network.networkConfig.name == "deopjib-dev";
+        assert network.networkConfig.interfaceName == "br-deopjib-dev";
+        assert builtins.elem 53 homelab.networking.firewall.interfaces.br-deopjib-dev.allowedUDPPorts;
         assert builtins.all (
           container:
           builtins.elem networkService container.unitConfig.PartOf
@@ -250,6 +252,7 @@
           ${pkgs.gnugrep}/bin/grep -F 'Requires=${networkService}' generated-units.txt >/dev/null
           ${pkgs.gnugrep}/bin/grep -F 'After=${networkService}' generated-units.txt >/dev/null
           ${pkgs.gnugrep}/bin/grep -F 'ExecStop=${podman}/bin/podman network rm deopjib-dev' generated-units.txt >/dev/null
+          ${pkgs.gnugrep}/bin/grep -F -- '--interface-name br-deopjib-dev' generated-units.txt >/dev/null
           ${pkgs.gnugrep}/bin/grep -F -- '--disable-dns hindsight-db' generated-units.txt >/dev/null
           ${pkgs.gnugrep}/bin/grep -F 'Requires=hindsight-db-network.service' generated-units.txt >/dev/null
 

--- a/systems/homelab/app-containers.nix
+++ b/systems/homelab/app-containers.nix
@@ -47,6 +47,7 @@ let
     );
 
   unitPrefixFor = app: "${app.contract.name}-${app.contract.channel}";
+  bridgeInterfaceFor = app: "br-${unitPrefixFor app}";
 
   caddyPortFor =
     app: if app.host.caddyPort == null then app.host.loopbackPortBase - 1 else app.host.caddyPort;
@@ -281,7 +282,10 @@ let
         After = [ podmanDnsLifecycleService ];
         PartOf = [ podmanDnsLifecycleService ];
       };
-      networkConfig.name = unitPrefix;
+      networkConfig = {
+        name = unitPrefix;
+        interfaceName = bridgeInterfaceFor app;
+      };
     };
 
   migrationServiceFor =
@@ -878,6 +882,10 @@ let
         message = "homelab.apps.${appName}: host.loopbackPortBase must be greater than 1024.";
       }
       {
+        assertion = builtins.stringLength (bridgeInterfaceFor app) <= 15;
+        message = "homelab.apps.${appName}: generated bridge interface must not exceed Linux's 15-character limit.";
+      }
+      {
         assertion = builtins.all (domain: domain == app.host.domain) routeDomains;
         message = "homelab.apps.${appName}: every contract route host must match host.domain.";
       }
@@ -954,6 +962,14 @@ let
   caddyPorts = mapAttrsToList (_appName: app: caddyPortFor app) enabledApps;
   serviceLoopbackPorts = flatten (
     mapAttrsToList (_appName: app: servicePortClaimsForApp app) enabledApps
+  );
+  appDnsFirewallInterfaces = listToAttrs (
+    mapAttrsToList (
+      _appName: app:
+      nameValuePair (bridgeInterfaceFor app) {
+        allowedUDPPorts = [ 53 ];
+      }
+    ) enabledApps
   );
 in
 {
@@ -1206,6 +1222,8 @@ in
     };
 
     services.cloudflared.tunnels.${cloudflareTunnelId}.ingress = appIngress;
+
+    networking.firewall.interfaces = appDnsFirewallInterfaces;
 
     virtualisation.quadlet = {
       networks = quadletNetworks;


### PR DESCRIPTION
## Summary
- derive a stable Linux bridge interface from each admitted app unit prefix
- allow Aardvark DNS traffic on that interface through the NixOS firewall
- validate the Linux interface-name limit and generated Quadlet command

## Root cause
The NixOS Podman module allowed UDP 53 only on `podman0`, while the Deopjib custom Quadlet network was dynamically created as `podman1`. Aardvark was healthy but DNS packets to `10.89.0.1:53` were dropped by the host firewall.

## Validation
- `nix fmt -- --ci`
- `nix flake check --no-build --all-systems`
- eval: `br-deopjib-dev` has `allowedUDPPorts = [ 53 ]`
- generated Quadlet invariant: `--interface-name br-deopjib-dev`

## Sources
- quadlet-nix locked README: custom networks require a stable `interfaceName` plus firewall UDP 53
- Podman Quadlet docs: `InterfaceName=` maps to `podman network create --interface-name`