### PR TITLE
feat(homelab): activate exact app release transactions

### DIFF
--- a/.github/workflows/deploy-homelab-app.yml
+++ b/.github/workflows/deploy-homelab-app.yml
@@ -10,10 +10,7 @@ on:
       channel:
         description: "Deploy channel"
         required: true
-        type: choice
-        options:
-          - dev
-          - prod
+        type: string
       target:
         description: "Release identifier to deploy, for example deopjib-v0.0.1"
         required: true
@@ -32,61 +29,12 @@ jobs:
       - homelab
     environment: ${{ inputs.channel == 'prod' && 'homelab-prod' || 'homelab-dev' }}
     steps:
-      - name: Validate request
-        run: |
-          set -euo pipefail
-
-          case "${APP}:${CHANNEL}" in
-            deopjib:dev | deopjib:prod)
-              ;;
-            *)
-              echo "::error::unsupported app/channel: ${APP}:${CHANNEL}" >&2
-              exit 1
-              ;;
-          esac
-
-          stable_release_id='^deopjib-v[0-9]+\.[0-9]+\.[0-9]+$'
-          dev_snapshot_id='^deopjib-v0\.0\.0-dev\.[0-9a-f]{7,40}$'
-          source_sha='^[0-9a-f]{40}$'
-
-          if printf '%s' "$TARGET" | grep -Eq "$stable_release_id"; then
-            exit 0
-          fi
-
-          if printf '%s' "$TARGET" | grep -Eq "$dev_snapshot_id"; then
-            if [ "$CHANNEL" = prod ]; then
-              echo "::error::prod dispatch requires a stable release id target, not a dev snapshot" >&2
-              exit 1
-            fi
-            exit 0
-          fi
-
-          if printf '%s' "$TARGET" | grep -Eq "$source_sha"; then
-            if [ "$CHANNEL" = prod ]; then
-              echo "::error::prod dispatch requires a release id target, not a transitional source SHA" >&2
-              exit 1
-            fi
-            exit 0
-          fi
-
-          if [ "$CHANNEL" = prod ]; then
-            echo "::error::prod target must be a Deopjib release id like deopjib-v0.0.1" >&2
-          else
-            echo "::error::target must be a Deopjib release id like deopjib-v0.0.1, a dev snapshot like deopjib-v0.0.0-dev.abcdef0, or a transitional full lowercase source SHA" >&2
-          fi
-          exit 1
-        env:
-          APP: ${{ inputs.app }}
-          CHANNEL: ${{ inputs.channel }}
-          TARGET: ${{ inputs.target }}
-
       - name: Deploy
         run: |
           set -euo pipefail
           appctl=/run/current-system/sw/bin/homelab-appctl
           sudo=/run/wrappers/bin/sudo
           "$sudo" -n "$appctl" deploy "$APP" "$CHANNEL" --target "$TARGET"
-          "$appctl" smoke "$APP" "$CHANNEL"
         env:
           APP: ${{ inputs.app }}
           CHANNEL: ${{ inputs.channel }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,5 +24,11 @@ jobs:
       - name: Check homelab Quadlet lifecycle
         run: nix build .#checks.x86_64-linux.homelab-quadlet-lifecycle-invariants --show-trace
 
+      - name: Check homelab release dry-run
+        run: nix build .#checks.x86_64-linux.homelab-appctl-release-dry-run --show-trace
+
+      - name: Check homelab release transaction
+        run: nix build .#checks.x86_64-linux.homelab-appctl-release-transaction --show-trace
+
       - name: Check root formatting
         run: nix build .#checks.x86_64-linux.formatting --show-trace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,8 +118,9 @@ Responsibility boundary:
   Cloudflared, Podman/Quadlet rendering, migrations, smoke checks, and
   `homelab-appctl`.
 - Do not add app-specific homelab deploy runners to app repos.
-- Treat OCI release manifests as optional provenance/audit artifacts only, not
-  the homelab deploy ABI.
+- For `manual` services, treat the app release manifest as the immutable image
+  identity. The admitted runtime, admission, manifest schema, and generator
+  source hashes remain the host policy boundary.
 
 Current host-side deploy ABI:
 
@@ -127,15 +128,16 @@ Current host-side deploy ABI:
 homelab-appctl list
 homelab-appctl status <app> <channel>
 homelab-appctl smoke <app> <channel>
-homelab-appctl deploy <app> <channel> --dry-run
-sudo -n homelab-appctl deploy <app> <channel>
-sudo -n homelab-appctl rollback <app> <channel>
+homelab-appctl deploy <app> <channel> --target <release-id> --dry-run
+sudo -n homelab-appctl deploy <app> <channel> --target <release-id>
 ```
 
 `homelab-appctl` is a `nix-dots` homelab adapter, not a public deploy platform.
 Portable app output is the OCI image plus documented runtime needs.
-`deploy` and `rollback` are root operations with a narrow passwordless sudo
-rule for the homelab operator user.
+`deploy` is a root operation with a narrow passwordless sudo rule for the
+homelab operator user. Roll back directly only within the admitted deployment
+source-hash set; otherwise revert the app input through PR/comin first. DB migrations are a
+separate recovery decision.
 
 ## Safety Rules
 

--- a/docs/guides/homelab-image-deploy-guide.md
+++ b/docs/guides/homelab-image-deploy-guide.md
@@ -1,530 +1,285 @@
 # Homelab Image Deploy Guide
 
-Audience: coding agents working in this repo or in app repos that deploy to the
-homelab.
+Audience: agents and operators changing an app repository or its NixOS homelab
+admission.
 
-Goal: app repos own deployable app intent; `nix-dots` owns host admission and
-runtime substrate. Do not hardcode app-specific runtime knowledge in `nix-dots`
-unless it is imported from an app-owned contract.
+## Decision
 
-Current direction: use per-app admission in `nix-dots` now. Move to k3s/Flux
-later when Kubernetes-backed self-service is worth the operational cost. Do not
-add a separate app catalog repo in between unless this decision is reopened.
-
-## Agent Rules
-
-- Treat app runtime shape as app-owned data.
-- Treat host binding as `nix-dots`-owned policy.
-- Prefer app-owned `devops/homelab-admission.nix` over chat or issue comments
-  that copy Nix snippets by hand.
-- Do not create a per-app NixOS stack by hand when an app contract can express
-  the same facts.
-- Do not put plaintext secrets in app repos or `nix-dots`.
-- Do not make routine image deploys require a NixOS rebuild.
-- Do not enable registry auto-update for services that run schema migrations on
-  start.
-- Keep new contracts close to Kubernetes primitives: image, service, secret env,
-  volume, route, health, migration, update policy, release channel.
-- Do not add app-specific homelab deploy scripts to app repos. App repos publish
-  images; `nix-dots` deploys admitted apps through `homelab-appctl`.
-- Use `homelab-appctl deploy <app> <channel> --target <identifier>` when the
-  app release has a verified immutable identifier such as `deopjib-v0.0.1`.
-  A full source SHA is acceptable during transition, but the durable deploy
-  target is the app release identifier. Deploy is a no-op only when the most
-  recent deploy record is successful and already has that target.
-
-## Ownership Boundary
-
-| Concern | Owner | Notes |
-|---|---|---|
-| OCI image build and tags | app repo | Publish immutable SHA tags; pointer tags are optional deploy channels. |
-| Runtime contract | app repo | Store as `devops/runtime-contract.nix`. |
-| Secret values | host/operator | Store through sops or future cluster secret management. |
-| Secret names required by the app | app repo | Declare as `requiredSecretEnv`; host maps them to actual secrets. |
-| Admission request | app repo proposes, `nix-dots` admits | Store as `devops/homelab-admission.nix` when structured handoff is needed. |
-| Public hostname and tunnel route | `nix-dots` | Host admission decision. |
-| Persistent volume location and backup policy | `nix-dots` | App may request a volume; host chooses storage. |
-| Runtime backend | `nix-dots` | Podman/Quadlet now, k3s later. |
-| Migration safety policy | app repo declares, host enforces | Host may reject unsafe auto-update combinations. |
-| Release command | app repo | Example: `mise run my-app:release-dev --minor`; starts app CI/release only. |
-| Host deploy command | `nix-dots` | `homelab-appctl deploy/smoke/rollback <app> <channel>`. |
-| OCI release manifest | app repo, optional | Provenance or audit artifact only; not the homelab deploy ABI. |
-
-## Portability Boundary
-
-`homelab-appctl` is a `nix-dots` homelab adapter, not a public deploy platform.
-It assumes this host's NixOS, Podman/Quadlet, Caddy, Cloudflared, sops, and
-systemd boundaries.
-
-The portable output of an app repo is the OCI image plus documented runtime
-needs: image refs, env, secret names, ports, routes, health paths, volumes,
-migration command, and release channel tags. Non-Nix users should consume those
-images through their own Docker Compose, Podman, Kubernetes, or platform-specific
-deployment layer.
-
-For this homelab, app contributors can trigger app releases if they have app repo
-permissions, but only the homelab-side runner applies the published image to the
-server. This keeps host secrets and runtime policy out of app repos.
-
-## Change Authority
-
-In the current phase, adding a new app requires a small `nix-dots` host binding
-entry. Routine releases after admission should not require `nix-dots` changes.
-
-| Change | Self-service by app repo? | Requires `nix-dots` review? |
-|---|---:|---:|
-| Move image pointer tag, for example `:dev-current` | yes | no |
-| Publish immutable image tag | yes | no |
-| Add or update `devops/homelab-admission.nix` | yes | yes, before import |
-| Change service image name | yes | yes |
-| Add or remove required secret env | yes | yes |
-| Add public route or hostname | no | yes |
-| Add persistent volume | no | yes |
-| Change migration mode | yes | yes |
-| Change runtime backend | no | yes |
-
-## Runtime Contract Schema
-
-Each app repo should provide a pure Nix data file:
+Each app repository owns its release artifacts and runtime intent. `nix-dots`
+owns whether and how that intent is admitted to the homelab.
 
 ```text
-devops/runtime-contract.nix
+app repo
+  runtime-contract.nix + homelab-admission.nix
+  release manifest + exact OCI image digests
+                |
+                v
+nix-dots flake input (pinned app revision)
+  typed admission + assertions
+  sops/network/storage/Caddy/Quadlet/systemd
+                |
+                v
+homelab-appctl deploy --target <release-id>
+  validate -> exact pull/tag -> migrate -> one restart -> smoke -> record
 ```
 
-The file must evaluate without importing `nixpkgs`, reading secrets, reading the
-network, or depending on the host. It is data, not deployment logic.
+This is intentionally smaller than Kubernetes, Nomad, or a separate app
+catalog. Revisit a controller only when several apps need continuous
+reconciliation, rollout strategies, or shared cluster primitives that are
+simpler than this host-local path.
 
-Required top-level fields:
+## Ownership
 
-| Field | Type | Meaning |
-|---|---|---|
-| `name` | string | Stable lowercase app id. Use in unit names and labels. |
-| `channel` | string | Deploy channel such as `dev`, `staging`, or `prod`. |
-| `images` | attrset string | Fully qualified OCI image references. |
-| `services` | attrset service | Runtime services exposed by the app. |
-| `routes` | list route | Requested HTTP routing shape. |
+| Concern | Authority |
+|---|---|
+| App version and release target | app repository |
+| Backend/web image build and release manifest | app repository |
+| Runtime services, dependencies, readiness, routes, and migrations | app-owned `devops/runtime-contract.nix` |
+| Proposed homelab binding | app-owned `devops/homelab-admission.nix` |
+| Admission and pinned app revision | `nix-dots` |
+| Secret values | sops-backed host configuration |
+| Network, storage, Caddy, Cloudflared, Quadlet, systemd | `nix-dots` |
+| Exact host activation and deploy records | `homelab-appctl` |
 
-Optional top-level fields:
+Do not copy an app's service graph into `systems/homelab/default.nix`. Import
+the app-owned admission through `systems/homelab/app-admissions.nix`, then let
+the typed `homelab.apps` module render it.
 
-| Field | Type | Default | Meaning |
-|---|---|---|---|
-| `migrations` | attrset | `{ mode = "none"; }` | Migration command and safety policy. |
-| `release` | attrset | `{ versioning = "external"; channels = { }; }` | Host deploy channel metadata. |
-| `volumes` | attrset volume | `{ }` | Persistent storage requests keyed by stable volume id. |
-| `notes` | string | `""` | Human/operator notes. |
+## App Contract
 
-Service fields:
+`devops/runtime-contract.nix` must be pure Nix data. It may be a function of
+admission parameters such as `channel` and `domain`, but must not import
+`nixpkgs`, read secrets, perform I/O, or contain host activation logic.
 
-| Field | Type | Required | Meaning |
-|---|---|---:|---|
-| `image` | string | yes | Key into `images`. |
-| `internalPort` | int | yes | Container listen port. |
-| `healthPath` | string | no | Path used for readiness/smoke checks. |
-| `env` | attrset string | no | Non-secret environment variables. |
-| `requiredSecretEnv` | list string | no | Secret env names the host must map. |
-| `updatePolicy` | enum | yes | `manual`, `registry-auto`, or `pinned-digest`. |
-| `volumeMounts` | list volumeMount | no | Requested mounts from top-level `volumes`. |
+The current typed contract supports:
 
-Volume fields:
+- `images`: fully qualified OCI references;
+- `services`: image key, internal port, env, required secret names, update
+  policy, mounts, `dependsOn`, optional HTTP health path, and optional native
+  container readiness command;
+- `routes`: domain/path/service mapping;
+- `migrations`: `none` or a manual one-shot command;
+- `release`: external versioning, HTTPS manifest URL containing `{target}`, and
+  channel tag/mode/target-pattern/strategy/smoke/migration policy;
+- `volumes`: stable logical volume requests.
 
-| Field | Type | Required | Meaning |
-|---|---|---:|---|
-| `notes` | string | no | Human/operator reason for the requested volume. |
+Update policies have distinct meanings:
 
-Volume mount fields:
+| Policy | Use |
+|---|---|
+| `manual` | Release-coordinated app services. The manifest supplies the exact digest. |
+| `pinned-digest` | Independently pinned infrastructure images such as PostgreSQL. |
+| `registry-auto` | Stateless services with explicitly safe independent updates only. |
 
-| Field | Type | Required | Meaning |
-|---|---|---:|---|
-| `volume` | string | yes | Key into top-level `volumes`. |
-| `mountPath` | string | yes | Container path. |
-| `readOnly` | bool | no | Defaults to `false`. |
+A `manual` service image must end in the admitted channel tag, for example
+`:dev-current`. That tag is a local activation pointer, not the release
+authority. The host pulls `name@sha256:...` from the release manifest and tags
+that exact image locally before restarting the service.
 
-Route fields:
+A `pinned-digest` image must end in `@sha256:<64 lowercase hex>`. It remains a
+normal declarative Quadlet image unit and does not participate in an app
+release transaction.
 
-| Field | Type | Required | Meaning |
-|---|---|---:|---|
-| `host` | string | yes | Requested public host. |
-| `path` | string | yes | Path matcher such as `/`, `/api/*`, `/health`. |
-| `service` | string | yes | Key into `services`. |
-
-Migration fields:
-
-| Field | Type | Required | Meaning |
-|---|---|---:|---|
-| `mode` | enum | yes | Current Podman renderer supports `none` or `manual`. |
-| `service` | string | if mode != `none` | Service image used for migration. |
-| `command` | list string | if mode != `none` | Command argv. |
-
-Release fields:
-
-| Field | Type | Required | Meaning |
-|---|---|---:|---|
-| `versioning` | enum | no | Must be `external`; app CI owns versioning. |
-| `channels` | attrset channel | no | Deploy channels keyed by `dev`, `prod`, etc. |
-
-Release channel fields:
-
-| Field | Type | Required | Meaning |
-|---|---|---:|---|
-| `tag` | string | yes | Channel pointer tag such as `dev-current`. |
-| `mode` | enum | no | `manual`, `auto`, or `approved`; current runner is host-local. |
-| `strategy` | enum | no | Current value: `coordinated`. |
-| `smokePaths` | list string | no | Paths checked through Caddy after deploy. |
-| `migrate` | enum | no | `none` or `manual`; `manual` requires manual migrations. |
-| `rollback` | enum | no | Current value: `record-only`. |
-
-Host policy:
-
-- `registry-auto` is not allowed on the service named by `migrations.service`.
-- Manual migrations render a host-local one-shot unit, but are never run during
-  NixOS activation or by background registry auto-update.
-- Every public service must have either `healthPath` or an explicit documented
-  reason why health checks are unavailable.
-
-## Runtime Contract Example
+Example release section:
 
 ```nix
-# devops/runtime-contract.nix
-{
-  name = "my-app";
-  channel = "dev";
-
-  images = {
-    api = "ghcr.io/example/my-app-api:dev-current";
-    web = "ghcr.io/example/my-app-web:dev-current";
-  };
-
-  services = {
-    api = {
-      image = "api";
-      internalPort = 4000;
-      healthPath = "/health";
-      env = {
-        APP_ENV = "dev";
-        PORT = "4000";
-      };
-      requiredSecretEnv = [
-        "DATABASE_URL"
-        "SECRET_KEY_BASE"
-      ];
-      updatePolicy = "manual";
-      volumeMounts = [
-        {
-          volume = "app-data";
-          mountPath = "/var/lib/my-app";
-        }
-      ];
-    };
-
-    web = {
-      image = "web";
-      internalPort = 8080;
-      updatePolicy = "registry-auto";
-    };
-  };
-
-  routes = [
-    {
-      host = "my-app.example.com";
-      path = "/health";
-      service = "api";
-    }
-    {
-      host = "my-app.example.com";
-      path = "/api/*";
-      service = "api";
-    }
-    {
-      host = "my-app.example.com";
-      path = "/";
-      service = "web";
-    }
-  ];
-
-  migrations = {
-    mode = "manual";
-    service = "api";
-    command = [ "/app/bin/migrate" ];
-  };
-
-  release = {
-    versioning = "external";
-    channels.dev = {
-      tag = "dev-current";
-      mode = "manual";
-      strategy = "coordinated";
-      smokePaths = [
-        "/health"
-        "/"
-      ];
-      migrate = "manual";
-      rollback = "record-only";
-    };
-  };
-
-  volumes.app-data = {
-    notes = "Persistent app data; host chooses storage class and backup policy.";
-  };
-}
-```
-
-## Homelab Admission Request
-
-To avoid copy-paste handoffs, an app repo may also provide:
-
-```text
-devops/homelab-admission.nix
-```
-
-This file is a structured request for host admission. It must not contain secret
-values and must not implement host runtime logic.
-
-```nix
-# devops/homelab-admission.nix
-{
-  key = "my-app";
-
-  app = {
-    enable = true;
-    contract = import ./runtime-contract.nix;
-
-    host = {
-      domain = "my-app.example.com";
-      loopbackPortBase = 18100;
-      registryAuth = "ghcr-readonly";
-
-      secretMap = {
-        DATABASE_URL = "MY_APP_DATABASE_URL";
-        SECRET_KEY_BASE = "MY_APP_SECRET_KEY_BASE";
-      };
-
-      volumes.app-data = {
-        backup = true;
-        class = "local-podman";
-      };
-    };
-  };
-}
-```
-
-The app repo owns this request. `nix-dots` still owns the decision to import it,
-the actual secret values, DNS/tunnel exposure, and volume policy. Later k3s/Flux
-can treat the same admission request as an allowlist entry for watched app paths.
-
-## Host Binding Shape
-
-For the current phase, `nix-dots` admits each app through a small host-owned
-binding. Prefer importing the app-owned admission request:
-
-```nix
-let
-  admission = import "${inputs.my-app}/devops/homelab-admission.nix";
-in
-{
-  homelab.apps.${admission.key} = admission.app;
-}
-```
-
-If the app repo does not yet provide an admission request, use the explicit
-fallback shape:
-
-```nix
-homelab.apps.my-app = {
-  enable = true;
-  contract = import "${inputs.my-app}/devops/runtime-contract.nix";
-
-  host = {
-    domain = "my-app.example.com";
-    loopbackPortBase = 18100;
-    registryAuth = "ghcr-readonly";
-
-    secretMap = {
-      DATABASE_URL = "MY_APP_DATABASE_URL";
-      SECRET_KEY_BASE = "MY_APP_SECRET_KEY_BASE";
-    };
-
-    volumes.my-app-db = {
-      backup = true;
-      class = "local-podman";
-    };
+release = {
+  versioning = "external";
+  manifestUrl = "https://github.com/example/my-app/releases/download/{target}/release.json";
+  channels.${channel} = {
+    tag = "${channel}-current";
+    mode = if channel == "prod" then "approved" else "auto";
+    targetPattern = if channel == "prod" then "^my-app-v[0-9]+\\.[0-9]+\\.[0-9]+$" else "^my-app-v.*$";
+    strategy = "coordinated";
+    smokePaths = [
+      "/health"
+      "/"
+    ];
+    migrate = "manual";
   };
 };
 ```
 
-The app contract says what is needed. The host binding says what is allowed and
-where host-owned resources come from.
+## Admission
 
-Keep this shape Kubernetes-mappable. It should describe admission, secrets,
-ports, routes, and volumes in terms that can later become Kubernetes namespace,
-Deployment, Service, Secret, PersistentVolumeClaim, and Ingress/Gateway
-resources.
+`devops/homelab-admission.nix` proposes a host binding:
 
-## Current Podman Renderer Requirements
-
-When implementing the Podman/Quadlet renderer in `nix-dots`, it must:
-
-- render Quadlet files under `/etc/containers/systemd/`
-- publish app ports to loopback only
-- route public traffic through Caddy and cloudflared
-- generate sops-backed env files from `secretMap`
-- order private registry image pulls after `sops-install-secrets.service`
-- add finite systemd start timeouts
-- add activation refresh logic for new or changed Quadlet files
-- render manual migration one-shot units
-- render `/etc/homelab-apps/<app>/<channel>.json` metadata for host commands
-- provide `homelab-appctl deploy/smoke/rollback <app> <channel>`
-- reject `registry-auto` on the service named by `migrations.service`
-- keep Hindsight special until its host-network dependencies are deliberately
-  migrated
-
-Renderer output should be inspectable with:
-
-```sh
-nix eval --raw '.#nixosConfigurations.homelab_hj.config.environment.etc."<quadlet-path>".text'
+```nix
+let
+  runtimeContract = ./runtime-contract.nix;
+in
+{
+  key = "my-app";
+  app = {
+    enable = true;
+    contract = import runtimeContract {
+      channel = "dev";
+      domain = "dev.my-app.example";
+    };
+    host = {
+      domain = "dev.my-app.example";
+      loopbackPortBase = 18100;
+      secretMap.DATABASE_URL = "MY_APP_DATABASE_URL";
+      volumes.db-data.backup = true;
+    };
+  };
+}
 ```
 
-## Release Automation
+The app file contains only secret names. Actual values remain in sops files and
+render to `/run/secrets/...` on the host. Public container ports bind to
+loopback; ingress remains Caddy plus Cloudflared.
 
-The comfortable app-side button lives in the app repo:
+`nix-dots` imports the proposal from its pinned flake input:
 
-```sh
-mise run my-app:release-dev --minor
+```nix
+let
+  admissionSource = "${inputs.myApp}/devops/homelab-admission.nix";
+  runtimeContractSource = "${inputs.myApp}/devops/runtime-contract.nix";
+  manifestSchemaSource = "${inputs.myApp}/devops/release-manifest.schema.json";
+  manifestGeneratorSource = "${inputs.myApp}/scripts/generate-release-manifest";
+  admission = import admissionSource;
+in
+{
+  homelab.apps.${admission.key} = admission.app // {
+    runtimeContractSourceSha256 = builtins.hashFile "sha256" runtimeContractSource;
+    homelabAdmissionSourceSha256 = builtins.hashFile "sha256" admissionSource;
+    manifestSchemaSourceSha256 = builtins.hashFile "sha256" manifestSchemaSource;
+    manifestGeneratorSourceSha256 = builtins.hashFile "sha256" manifestGeneratorSource;
+    host = admission.app.host // {
+      releaseManifestOrigins = [ "https://github.com/example/my-app" ];
+    };
+  };
+}
 ```
 
-That command should create the release PR, run CI, publish OCI images, and move
-the channel tag such as `dev-current`. It must not SSH into homelab and must not
-carry app-specific host deploy logic.
+The module rejects invalid ids, routes, dependencies, secret mappings, volume
+mappings, unsafe migration/auto-update combinations, malformed digests, and
+manual services without an HTTPS manifest URL under a host-admitted origin and
+a matching channel tag.
 
-The homelab applies published images through the generic runner generated by
-`nix-dots`:
+## Release Manifest
+
+For release-managed services, the app's release manifest is the immutable
+artifact identity. It must include:
+
+- schema version, app id, release target, version, source revision, and creation
+  time;
+- every admitted release-managed image name and exact digest;
+- SHA-256 of the app-owned runtime contract, admission, manifest schema, and
+  manifest generator sources.
+
+The host accepts a manifest only when its app, target, all deployment source hashes,
+image names, and digest syntax match generated admission metadata. This makes
+the release artifact authoritative for image identity without giving the app
+repository authority over host secrets or topology.
+
+Pointer tags such as `dev-current` and `prod-current` remain useful for humans
+and local container references. They must never decide which remote bytes are
+deployed.
+
+## Generated NixOS Runtime
+
+The `homelab.apps` module renders:
+
+- Podman networks, volumes, containers, and only the independently managed
+  Quadlet image units;
+- native systemd `Requires`/`After` edges from `dependsOn`;
+- Quadlet health checks and `Notify=healthy` from `readiness`;
+- sops-backed env files;
+- manual migration one-shot units;
+- loopback Caddy routes and Cloudflared ingress;
+- `/etc/homelab-apps/<app>/<channel>.json` admission metadata;
+- the generic `homelab-appctl` package and a deploy-only sudo rule.
+
+Release-managed containers use the admitted channel reference with
+`Pull=never`. `homelab-appctl` is the single owner of exact pull/tag and release
+restart. This avoids the former double restart where Quadlet image units moved
+tags and the deploy command restarted containers a second time.
+
+## Deploy Flow
+
+The host interface is:
 
 ```sh
 homelab-appctl list
-homelab-appctl status my-app dev
-homelab-appctl smoke my-app dev
-homelab-appctl deploy my-app dev --dry-run --target <release-id>
-sudo -n homelab-appctl deploy my-app dev --target <release-id>
-sudo -n homelab-appctl rollback my-app dev
+homelab-appctl status <app> <channel>
+homelab-appctl smoke <app> <channel>
+homelab-appctl deploy <app> <channel> --target <release-id> --dry-run
+sudo -n homelab-appctl deploy <app> <channel> --target <release-id>
+homelab-appctl logs <app> <channel>
 ```
 
-For Deopjib, app CI should not ask developers to run those commands manually.
-The app repo dispatches this repo's `Deploy Homelab App` workflow with
-`app=deopjib`, `channel=dev|prod`, and a release identifier target such as
-`deopjib-v0.0.1`. A full source SHA is allowed only as a transition format while
-the app workflow still promotes SHA-tagged images. That workflow must run on the
-homelab self-hosted runner and call the same host-local `homelab-appctl`
-commands.
+`--dry-run` performs read-only manifest download and admission validation, then
+prints exact images, migration unit, release service units, and smoke paths.
 
-Required wiring:
+A real deploy:
 
-- this repo has a GitHub Actions runner on the homelab with labels
-  `self-hosted` and `homelab`
-- the app repo has a dispatch token secret that can call this repo's Actions
-  workflow dispatch API with repo-level Actions write permission
-- workflow input validation, the allowlist, and the prod gate are the guards;
-  the dispatch token itself is not scoped to one workflow or input set
+1. Rejects an invalid target or missing metadata.
+2. Acquires a host-local app/channel lock and treats a target as a no-op only
+   when the latest successful record used byte-identical admitted metadata.
+3. Downloads and validates the release manifest.
+4. Snapshots current local image ids.
+5. Pulls each admitted `image@digest` and moves only its local channel tag.
+6. Runs the declared migration once.
+7. Restarts all release-managed services in one systemd transaction. Pinned
+   dependencies such as PostgreSQL are not restarted.
+8. Runs declared Caddy-loopback smoke checks once.
+9. Publishes an `in-progress` record before image mutation, then records target,
+   metadata, images, migration, smoke, and final result under
+   `/var/lib/homelab-appctl/<app>/<channel>/`.
 
-Deploy order:
+If pull, tag, or migration fails, the command records failure and restores prior
+local channel tags where applicable. If restart or smoke fails, deploy a known
+good release target. If its source hashes differ, first revert the pinned app
+input through PR/comin, then deploy that target. There is no separate rollback
+subcommand because it would create a second release authority. Image rollback
+never rolls back database migrations automatically.
 
-1. Read `/etc/homelab-apps/<app>/<channel>.json`.
-2. Compare `--target <identifier>` with the most recent deploy record.
-3. If the most recent record is successful and the target already matches, exit
-   without pulling, migrating, restarting, or smoking.
-4. Pull image units and record local image IDs.
-5. Run the manual migration unit if the contract declares one.
-6. Restart generated app service units.
-7. Smoke-test declared paths through Caddy loopback with the public Host header.
-8. Write a deploy record under `/var/lib/homelab-appctl/<app>/<channel>/`,
-   including target, image refs and IDs, migration result, smoke result, and
-   final result when available.
+## Change and Activation Workflow
 
-`deploy` and `rollback` are root operations because they write
-`/var/lib/homelab-appctl` and control system services. `nix-dots` installs a
-narrow passwordless sudo rule for the homelab operator user that allows only
-`homelab-appctl deploy *` and `homelab-appctl rollback *`.
+Routine app releases whose runtime contract is unchanged do not update the Nix
+flake or rebuild NixOS. App CI publishes a release manifest and dispatches the
+host-owned deploy workflow with the release target.
 
-Rollback is intentionally conservative in the current Podman phase. The command
-exists and reports the previous image records, but automatic image restoration is
-enabled only after that path is proven safe for the app and its migrations.
+When runtime intent changes:
 
-OCI release manifests may exist in app CI for audit/provenance, but they are not
-the deploy ABI. The deploy ABI is the app-owned runtime contract plus the host
-metadata generated by `nix-dots`.
+1. Merge the app contract/admission change and publish its release manifest.
+2. App CI must not auto-deploy while any deployment source hash is not admitted.
+3. Update only the app input in `nix-dots` and review the lock diff.
+4. Run Nix evaluation and generated-runtime checks.
+5. Merge the `nix-dots` PR; let comin activate it on the homelab.
+6. Dispatch the same release target. The host now accepts its source hashes and
+   exact image digests.
 
-## Future k3s Path
+Do not run ad-hoc `nixos-rebuild` from a development Mac for this GitOps host.
+Local work proves evaluation; the PR, CI, and comin path owns activation.
 
-Introduce k3s/Flux later when the homelab needs true app-owned runtime
-reconciliation.
-
-In that mode:
-
-- `nix-dots` owns k3s, Flux, storage classes, ingress/tunnel policy, and cluster
-  security baseline
-- app repos own Kubernetes manifests, Helm charts, or generated manifests from
-  the same `runtime-contract.nix`
-- Flux watches approved app repo paths
-- image tag updates remain routine app-owned deploys
-- host/cluster policy still owns secrets and public exposure
-
-Do not introduce k3s just to move one app's runtime fields out of `nix-dots`.
-Use k3s when app count, rollout needs, or self-service policy boundaries justify
-the operational cost.
-
-When migrating, preserve the app-owned `runtime-contract.nix` as the source of
-truth. The Podman renderer should be replaceable by a Kubernetes renderer rather
-than requiring each app to redesign its deploy contract.
-
-## Agent Workflow
-
-When asked to add a new homelab app:
-
-1. Inspect the app repo for `devops/homelab-admission.nix`.
-2. If it is missing, inspect or add `devops/runtime-contract.nix` in the app
-   repo first, then ask the app repo to add the admission request.
-3. Import only the reviewed admission request into `homelab.apps.<key>`.
-4. Validate that all images are fully qualified OCI references.
-5. Check that every `requiredSecretEnv` has a proposed host secret mapping.
-6. Check migration/update safety:
-   - allow `registry-auto` for stateless services
-   - prefer `manual` for DB-backed services
-   - reject registry auto-update on the migration service
-   - keep release channel rollback as `record-only` unless automatic image
-     restore has been proven on homelab
-7. Add or update only the host binding in `nix-dots`.
-8. Evaluate generated Quadlet/Caddy/sops/app metadata output.
-9. Run `homelab-appctl smoke <app> <channel>` after deployment.
-
-## Podman Smoke Checks
-
-After deployment to homelab:
+Focused local validation while developing both repositories:
 
 ```sh
-systemctl is-active podman-auto-update.timer
-systemctl list-units --no-legend --plain '*my-app*'
-find /etc/containers/systemd -maxdepth 1 -iname '*my-app*' -print
-podman auto-update --dry-run
-homelab-appctl smoke my-app dev
-sudo -n homelab-appctl deploy my-app dev --dry-run --target <release-id>
+nix fmt --override-input myApp path:/absolute/path/to/app
+nix flake check --all-systems --no-build --show-trace --no-write-lock-file \
+  --override-input myApp path:/absolute/path/to/app
 ```
 
-Expected result:
+The Linux-only checks build in CI. They execute the app-owned manifest producer,
+negative admission cases, the generated appctl dry-run, a stubbed full deploy
+transaction including failure recovery and concurrent calls, and Quadlet
+dependencies/readiness. Release deployment must exclude the pinned database
+service.
 
-- app units are running from declared images
-- public health route reaches the intended service
-- backend/web ports are not directly public
-- registry auto-update applies only to services with safe rollback behavior
+## New App Checklist
 
-## Acceptance Checklist
-
-Before a change is ready:
-
-- app repo has `devops/runtime-contract.nix`
-- structured handoff uses `devops/homelab-admission.nix` when available
-- contract is pure data and evaluates locally
-- `nix-dots` contains only host binding, not copied app runtime details
-- every required secret env maps to a host secret
-- every public route is intentionally exposed
-- migration and update policy do not conflict
-- generated runtime output is evaluated
-- generated app metadata is evaluated
-- live deployment smoke checks are documented
+- Add a pure app-owned runtime contract and structured admission request.
+- Use exact digests for independently pinned stateful dependencies.
+- Declare service dependencies and readiness in the contract, not in shell
+  sleeps.
+- Keep secret values in sops and ports loopback-only.
+- Import the admission from one pinned flake input.
+- Verify generated metadata, Quadlet, Caddy, and migration units.
+- Publish an immutable release manifest for manual services.
+- Use the generic host workflow and `homelab-appctl`; do not add per-app SSH or
+  systemd scripts.
+- Prove backup/restore and decide data-retention semantics before production
+  admission.

--- a/docs/plans/2026-04-30-001-feat-homelab-app-release-automation-plan.md
+++ b/docs/plans/2026-04-30-001-feat-homelab-app-release-automation-plan.md
@@ -1,11 +1,15 @@
 ---
 title: "feat: homelab app release automation substrate"
 type: feat
-status: planned
+status: superseded
 date: 2026-04-30
+superseded_by: ../solutions/architecture-patterns/homelab-app-contract-generic-deploy-runner-2026-05-06.md
 ---
 
 # feat: homelab app release automation substrate
+
+> Superseded on 2026-07-20. The current release ABI and host transaction are
+> documented in `../solutions/architecture-patterns/homelab-app-contract-generic-deploy-runner-2026-05-06.md`.
 
 ## Summary
 

--- a/docs/solutions/architecture-patterns/homelab-app-contract-generic-deploy-runner-2026-05-06.md
+++ b/docs/solutions/architecture-patterns/homelab-app-contract-generic-deploy-runner-2026-05-06.md
@@ -1,208 +1,181 @@
 ---
 title: Homelab app contracts with a generic host deploy runner
 date: 2026-05-06
+last_verified: 2026-07-20
 category: architecture-patterns
 module: homelab-app-runtime
 problem_type: architecture_pattern
 component: development_workflow
 severity: medium
 applies_when:
-  - "App repos publish OCI images but should not know homelab internals"
-  - "Routine dev deploys should not require a NixOS rebuild"
-  - "Podman/Quadlet is the current renderer but k3s may replace it later"
+  - "App repositories publish OCI images but should not know homelab internals"
+  - "Routine image releases should not require a NixOS rebuild"
+  - "A coordinated release contains more than one application image"
 related_components:
   - nix-dots
   - podman
   - quadlet
+  - systemd
   - caddy
   - cloudflared
   - sops-nix
-  - kubernetes
-tags: [homelab, runtime-contract, podman, quadlet, app-deploy, release-automation, k3s]
+tags: [homelab, runtime-contract, release-manifest, exact-digest, podman, quadlet, app-deploy]
 ---
 
 # Homelab app contracts with a generic host deploy runner
 
-## Context
+## Problem
 
-The homelab needed a low-friction deploy path for development apps without
-turning `nix-dots` into an app release platform. The pressure point was
-Deopjib: its app repo can build and publish OCI images, but hard-coding
-Deopjib-specific Quadlet, Caddy, secrets, migration, and release logic directly
-in `nix-dots` would make every new app a custom host change.
+The first generic runner treated mutable Quadlet image units as the deploy
+authority and restarted those units before restarting the app services. A
+coordinated backend/web release therefore had two activation paths. On Deopjib,
+the database and backend could also start without an explicit readiness edge,
+causing transient DNS and PostgreSQL startup failures before a later retry
+passed.
 
-The user also expects a later k3s/Flux migration. That makes the near-term
-boundary more important: app intent should be expressed as data close to
-Kubernetes primitives, while the current host renderer can stay Podman/Quadlet.
+An optional release manifest did not solve this. A release containing two image
+digests needs one immutable identity; reconstructing it from mutable channel
+tags makes the result timing-dependent.
 
-Session history showed the same boundary emerging earlier: a Deopjib dev deploy
-worked best when the app repo owned `devops/runtime-contract.nix` and
-`devops/homelab-admission.nix`, while `nix-dots` imported that contract and
-owned the host envelope, generated units, ingress, and secrets (session
-history). A separate Podman migration also established that NixOS should own the
-stable runtime envelope while image updates happen through the container runtime
-rather than through routine NixOS rebuilds (session history).
+## Decision
 
-## Guidance
+Keep two authorities with a narrow join:
 
-Use a three-layer model:
+- the app repository owns release target, exact application image digests, and
+  runtime intent;
+- `nix-dots` owns admission, the pinned app revision, secrets, network,
+  storage, ingress, Quadlet/systemd rendering, and host activation.
 
-1. App repo owns the release and runtime intent.
-2. `nix-dots` admits that intent onto a host and enforces policy.
-3. A host-local generic command deploys admitted apps from generated metadata.
+The join is the SHA-256 set for the runtime contract, homelab admission,
+manifest schema, and manifest generator. App CI writes all four into the release
+manifest. NixOS independently writes the pinned values into generated app
+metadata. `homelab-appctl` rejects a release when any differs.
 
-The app-owned contract should stay pure data. It can describe images, services,
-ports, health paths, required secret names, routes, volumes, migrations, update
-policy, and release channels. It should not import `nixpkgs`, read secrets,
-read host state, run network calls, or know where the homelab stores generated
-files.
+For `manual` services:
 
-The host binding should stay small and policy-shaped:
+- the release manifest is the immutable image identity;
+- Quadlet uses the channel reference with `Pull=never`;
+- no `.image` unit is rendered;
+- `homelab-appctl` pulls `name@digest`, moves the local channel tag, migrates,
+  and restarts all release-managed services once.
 
-```nix
-homelab.apps.my-app = {
-  enable = true;
-  contract = import "${inputs.my-app}/devops/runtime-contract.nix";
+For `pinned-digest` services:
 
-  host = {
-    domain = "dev.example.test";
-    loopbackPortBase = 18100;
-    registryAuth = "ghcr-readonly";
+- the contract contains the complete `name:tag@sha256:...` reference;
+- the normal declarative Quadlet image unit remains;
+- app releases do not restart that service.
 
-    secretMap = {
-      DATABASE_URL = "MY_APP_DEV_DATABASE_URL";
-      SECRET_KEY_BASE = "MY_APP_DEV_SECRET_KEY_BASE";
-    };
-  };
-};
-```
+Service graph facts stay in the app contract. `dependsOn` becomes native
+systemd `Requires`/`After`; `readiness` becomes Quadlet health settings and
+`Notify=healthy`. Each channel also admits an explicit target pattern, so a prod
+channel can reject dev snapshot targets before mutation. This replaces retry
+sleeps and host-specific scripts.
 
-Routine app release commands belong in app repos. For example,
-`mise run deopjib:release-dev --minor` can create a PR, run CI, decide version
-intent, publish OCI images, and move a channel pointer tag such as
-`:dev-current`. It should not SSH into homelab or run an app-specific host
-deploy script.
-
-`nix-dots` should expose the host deploy surface generically:
-
-```sh
-homelab-appctl list
-homelab-appctl status <app> <channel>
-homelab-appctl smoke <app> <channel>
-homelab-appctl deploy <app> <channel> --dry-run --target <identifier>
-sudo -n homelab-appctl deploy <app> <channel> --target <identifier>
-sudo -n homelab-appctl rollback <app> <channel>
-```
-
-`homelab-appctl` reads generated metadata under
-`/etc/homelab-apps/<app>/<channel>.json`. That path is a host adapter detail,
-not a public app ABI. The portable app output remains the OCI image plus the
-documented runtime needs.
-
-`deploy` and `rollback` are root operations because they write
-`/var/lib/homelab-appctl` and control system services. Keep the sudo surface
-narrow: the homelab operator may run only those two subcommands without a
-password.
-
-Do not make the optional OCI release manifest the deploy ABI. It is useful for
-audit and provenance, but the host should deploy from admitted app metadata and
-the app-owned runtime contract.
-
-## Why This Matters
-
-This keeps responsibilities narrow:
-
-- App repos can move fast on release PRs, SemVer, CI, image publication, and
-  channel tags.
-- `nix-dots` keeps control of host admission, registry credentials, sops-backed
-  secrets, persistent volumes, public ingress, Caddy, Cloudflared, Podman, and
-  migration safety.
-- Routine dev deploys do not require a NixOS rebuild once an app is admitted.
-- Migration-owning services are protected from blind `registry-auto` updates.
-- A later k3s renderer can consume the same app contract shape rather than
-  reverse-engineering Podman-specific scripts.
-
-The key design constraint is to avoid a false self-service surface. App repos
-should be self-service for releases after admission, but not for host policy,
-secrets, public domains, storage, or migration execution.
-
-## When to Apply
-
-- A new internal app needs to run on the homelab from an OCI image.
-- An app repo wants one command to start a dev release workflow.
-- The host already has an admitted app and routine deploys should be image tag
-  movement plus `homelab-appctl deploy`.
-- The current implementation is Podman/Quadlet, but the contract should remain
-  portable enough for a future k3s/Flux renderer.
-
-Do not apply this pattern to Hindsight yet without a separate redesign.
-Hindsight has host-network and local AI dependencies that are deliberately
-special in this repo.
-
-## Examples
-
-### Runtime contract release block
-
-Keep release metadata declarative and host-relevant:
-
-```nix
-release = {
-  versioning = "external";
-
-  channels.dev = {
-    tag = "dev-current";
-    mode = "manual";
-    strategy = "coordinated";
-    smokePaths = [
-      "/health"
-      "/"
-    ];
-    migrate = "manual";
-    rollback = "record-only";
-  };
-};
-```
-
-`versioning = "external"` is the important boundary. `nix-dots` does not infer
-SemVer from app commits; app CI owns that.
-
-### Host deploy sequence
-
-The host-side deploy path should be predictable and metadata-driven:
+## Deploy Transaction
 
 ```text
-read generated metadata
-compare release target with the most recent deploy record
-pull/resolve service images
-run manual migration unit if declared
-restart rendered service units
-smoke through Caddy using the public Host header
-record target, before/after image state, migration result, smoke result, and final result
+release target
+  -> download manifest
+  -> validate app, target, deployment source hashes, image names, exact digests
+  -> acquire app/channel lock and publish in-progress record
+  -> snapshot local image ids
+  -> pull exact application digests
+  -> move local channel tags
+  -> run migration once
+  -> restart release-managed units once as one systemd transaction
+  -> smoke declared paths once
+  -> write deploy record
 ```
 
-When the most recent deploy record is successful and already has the requested
-target, deploy may no-op. A newer failed record must allow retry even when an
-older successful record has the same target.
+A successful target is a no-op only when the latest record also contains
+byte-identical admitted metadata. That prevents a contract change from being
+hidden behind an old release id.
 
-`rollback = "record-only"` is intentionally conservative. Until image restore
-and migration rollback are proven, rollback should report the prior image state
-instead of pretending to be fully automatic.
+There is no rollback subcommand. Rollback is a deploy of a known-good release
+target through the same path. If that target belongs to an older deployment
+contract, first revert the pinned app input through PR/comin. Database migrations
+remain an explicit recovery concern.
 
-### Anti-patterns
+## NixOS Integration
 
-- Adding `systems/homelab/deopjib-stack.nix` by hand when the app repo can
-  provide a runtime contract.
-- Giving app CI broad SSH access to the homelab.
-- Running migrations during NixOS activation.
-- Enabling `registry-auto` on the service that owns schema migrations.
-- Copying a chat snippet like `homelab.apps.deopjib = { ... }` between repos as
-  the long-term interface.
-- Introducing k3s only to avoid writing a small host admission binding.
+The app repository exports:
 
-## Related
+```text
+devops/runtime-contract.nix
+devops/homelab-admission.nix
+```
 
-- [`../tooling-decisions/homelab-podman-quadlet-runtime-migration-2026-04-27.md`](../tooling-decisions/homelab-podman-quadlet-runtime-migration-2026-04-27.md) — explains why Podman/Quadlet is the current homelab renderer and why image hot-swap should not require Docker or a NixOS rebuild.
-- [`../../guides/homelab-image-deploy-guide.md`](../../guides/homelab-image-deploy-guide.md) — operator and agent guide for app-owned runtime contracts, admission, and host deploy commands.
-- [`../../plans/2026-04-30-001-feat-homelab-app-release-automation-plan.md`](../../plans/2026-04-30-001-feat-homelab-app-release-automation-plan.md) — implementation plan for the generic release automation substrate.
-- `systems/homelab/app-containers.nix` — current NixOS module that renders admitted app contracts, metadata, migration units, and `homelab-appctl`.
-- `rules/repo-policy.md` — compact agent rules for preserving the app contract and host runtime boundary.
+`nix-dots` pins the app repository as a flake input and imports only the
+admission request from `systems/homelab/app-admissions.nix`. The typed
+`homelab.apps` module adds the allowed HTTPS release origin, validates, and
+renders it. Host-specific values do not go
+in `systems/homelab/default.nix`, and no activation shell script performs app
+deployment.
+
+Routine image releases do not move the flake input. A contract change does:
+
+1. app release is published but automatic host dispatch stops;
+2. a `nix-dots` PR updates only the app input and validates generated output;
+3. comin activates merged NixOS configuration;
+4. the same release target is dispatched and now passes source-hash admission.
+
+For the first strict-manifest cutover, that app release must reuse the currently
+known-good backend/web digest pair. After comin activation, dry-run and deploy
+that same target first so the new controller has a compatible `ok` rollback
+baseline before any later image release.
+
+This keeps NixOS declarative while avoiding a NixOS rebuild for every app image
+release.
+
+## Verification
+
+Local macOS validation evaluates all outputs without pretending to build Linux:
+
+```sh
+nix flake check --all-systems --no-build --show-trace --no-write-lock-file \
+  --override-input deopjibRuntime path:/absolute/path/to/app
+```
+
+Linux CI additionally runs:
+
+- an app-generator-produced manifest, negative admission cases, and a generated
+  `homelab-appctl deploy --dry-run`;
+- a stubbed full deploy transaction covering exact pulls/tags, migration,
+  combined restart, no-op, recovery failure, and concurrent calls;
+- Quadlet lifecycle assertions for direct release refs, `Pull=never`, native DB
+  readiness, and backend-to-DB ordering;
+- an assertion that only one release-service restart command exists and no
+  image unit is restarted.
+
+Host verification after activation must confirm:
+
+```sh
+homelab-appctl deploy deopjib dev --target <release-id> --dry-run
+sudo -n homelab-appctl deploy deopjib dev --target <release-id>
+systemctl show deopjib-dev-db.service deopjib-dev-backend.service deopjib-dev-web.service \
+  -p ActiveState -p SubState -p NRestarts
+homelab-appctl smoke deopjib dev
+```
+
+The deploy log should contain exact digest pulls, one migration, one combined
+backend/web restart, and one smoke pass. It must not restart PostgreSQL.
+
+## Rejected Alternatives
+
+- Per-app host scripts duplicate admission, sudo, secret, migration, and smoke
+  policy.
+- Mutable channel tags cannot identify a coordinated multi-image release.
+- A NixOS rebuild per image release couples app cadence to host configuration.
+- Kubernetes, Flux, Nomad, or a separate app catalog add a controller before
+  the current single-host requirement needs one.
+
+Revisit a controller when multiple apps require continuous reconciliation,
+rollout strategies, multi-host scheduling, or shared cluster primitives that
+make the controller smaller than this runner.
+
+## References
+
+- `systems/homelab/app-containers.nix`
+- `systems/homelab/app-admissions.nix`
+- `.github/workflows/deploy-homelab-app.yml`
+- `docs/guides/homelab-image-deploy-guide.md`

--- a/flake.lock
+++ b/flake.lock
@@ -46,16 +46,15 @@
     "deopjibRuntime": {
       "flake": false,
       "locked": {
-        "lastModified": 1778043520,
-        "narHash": "sha256-yxdGhNNjaNpMBv7i+VKBtzqsmT//pgObUIY9GED6qqQ=",
+        "lastModified": 1784555092,
+        "narHash": "sha256-AqktW/0G6vcTWMwpMiONkhAdykluCBWkZVxQsGbbi2c=",
         "owner": "rjcnd105",
         "repo": "my-app",
-        "rev": "a2e2763f1efbd9258b4e47e43a065b64b2b90792",
+        "rev": "ad6a8af849afb7edb1b591fac8466e4f312157cd",
         "type": "github"
       },
       "original": {
         "owner": "rjcnd105",
-        "ref": "feat/deopjib-runtime-contract",
         "repo": "my-app",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
     quadlet-nix.url = "github:SEIAROTg/quadlet-nix";
 
     deopjibRuntime = {
-      url = "github:rjcnd105/my-app/feat/deopjib-runtime-contract";
+      url = "github:rjcnd105/my-app";
       flake = false;
     };
 
@@ -147,6 +147,59 @@
 
       treefmtEval = eachSystem (system: treefmt-nix.lib.evalModule (pkgsFor system) treefmtModule);
 
+      homelabAppctlTestContext =
+        let
+          pkgs = pkgsFor "x86_64-linux";
+          homelab = self.nixosConfigurations.homelab_hj.config;
+          appctl =
+            lib.findFirst (package: lib.getName package == "homelab-appctl")
+              (throw "homelab-appctl is missing from the homelab system packages")
+              homelab.environment.systemPackages;
+          metadata = pkgs.writeText "deopjib-dev-metadata.json" (
+            homelab.environment.etc."homelab-apps/deopjib/dev.json".text
+          );
+          releaseManifest =
+            pkgs.runCommand "deopjib-release-manifest-fixture"
+              {
+                nativeBuildInputs = [
+                  pkgs.check-jsonschema
+                  pkgs.coreutils
+                  pkgs.jq
+                ];
+              }
+              ''
+                ${pkgs.bash}/bin/bash ${deopjibRuntime}/scripts/deopjib-generate-release-manifest \
+                  --version 0.0.0-dev.0000000 \
+                  --source-rev 0000000000000000000000000000000000000000 \
+                  --backend-name ghcr.io/rjcnd105/deopjib-backend \
+                  --backend-tag 0000000000000000000000000000000000000000 \
+                  --backend-digest sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+                  --backend-status changed \
+                  --web-name ghcr.io/rjcnd105/deopjib-web \
+                  --web-tag 0000000000000000000000000000000000000000 \
+                  --web-digest sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+                  --web-status changed \
+                  --deployment-contract-status changed \
+                --runtime-contract-source ${deopjibRuntime}/deopjib/devops/runtime-contract.nix \
+                --homelab-admission-source ${deopjibRuntime}/deopjib/devops/homelab-admission.nix \
+                --manifest-schema-source ${deopjibRuntime}/deopjib/devops/release-manifest.schema.json \
+                --manifest-generator-source ${deopjibRuntime}/scripts/deopjib-generate-release-manifest \
+                  --generated-at 2026-07-20T00:00:00Z \
+                  --output "$out"
+                check-jsonschema \
+                  --schemafile ${deopjibRuntime}/deopjib/devops/release-manifest.schema.json \
+                  "$out"
+              '';
+        in
+        {
+          inherit
+            appctl
+            metadata
+            pkgs
+            releaseManifest
+            ;
+        };
+
       homelabAppctlDeployInvariants =
         system:
         let
@@ -155,14 +208,285 @@
         pkgs.runCommand "homelab-appctl-deploy-invariants" { } ''
           app_containers=${./systems/homelab/app-containers.nix}
 
-          ${pkgs.gnugrep}/bin/grep -F 'systemctl restart "$image_unit"' "$app_containers" >/dev/null
-          if ${pkgs.gnugrep}/bin/grep -F 'systemctl start "$image_unit"' "$app_containers" >/dev/null; then
-            echo 'homelab-appctl deploy must restart image pull units; start is a no-op for active oneshot .image units' >&2
+          ${pkgs.gnugrep}/bin/grep -F 'podman pull' "$app_containers" >/dev/null
+          ${pkgs.gnugrep}/bin/grep -F 'podman tag' "$app_containers" >/dev/null
+          ${pkgs.gnugrep}/bin/grep -F 'mapfile -t release_service_units' "$app_containers" >/dev/null
+          [ "$(${pkgs.gnugrep}/bin/grep -Fc 'systemctl restart ' "$app_containers")" -eq 1 ]
+          if ${pkgs.gnugrep}/bin/grep -F 'systemctl restart "$image_unit"' "$app_containers" >/dev/null; then
+            echo 'homelab-appctl must pull exact release digests without restarting Quadlet image units' >&2
             exit 1
           fi
 
           touch "$out"
         '';
+
+      homelabAppctlReleaseDryRun =
+        let
+          inherit (homelabAppctlTestContext)
+            appctl
+            metadata
+            pkgs
+            releaseManifest
+            ;
+        in
+        pkgs.runCommand "homelab-appctl-release-dry-run"
+          {
+            nativeBuildInputs = [
+              appctl
+              pkgs.gnugrep
+              pkgs.jq
+            ];
+          }
+          ''
+            set -eu
+
+            target=deopjib-v0.0.0-dev.0000000
+            metadata_root="$PWD/metadata"
+            state_root="$PWD/state"
+            manifest="$PWD/release-manifest-$target.json"
+            manifest_template="file://$PWD/release-manifest-{target}.json"
+            mkdir -p "$metadata_root/deopjib" "$state_root"
+
+            backend_name=$(jq -r '.services[] | select(.imageKey == "backend") | .imageName' ${metadata})
+            web_name=$(jq -r '.services[] | select(.imageKey == "web") | .imageName' ${metadata})
+            install -m 0644 ${releaseManifest} "$manifest"
+
+            jq --arg manifestUrl "$manifest_template" \
+              '.release.manifestUrl = $manifestUrl' \
+              ${metadata} > "$metadata_root/deopjib/dev.json"
+
+            HOMELAB_APPCTL_METADATA_ROOT="$metadata_root" \
+              HOMELAB_APPCTL_STATE_ROOT="$state_root" \
+              HOMELAB_APPCTL_TEST_ALLOW_FILE_URL=1 \
+              homelab-appctl deploy deopjib dev --target "$target" --dry-run > dry-run.out
+
+            grep -F "$backend_name@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" dry-run.out >/dev/null
+            grep -F "$web_name@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" dry-run.out >/dev/null
+            grep -F 'deopjib-dev-backend.service' dry-run.out >/dev/null
+            grep -F 'deopjib-dev-web.service' dry-run.out >/dev/null
+            grep -F 'deopjib-dev-migrate.service' dry-run.out >/dev/null
+            if grep -F 'deopjib-dev-db.service' dry-run.out >/dev/null; then
+              echo 'release dry-run must not include the pinned database service' >&2
+              exit 1
+            fi
+
+            cp "$manifest" valid-manifest.json
+            expect_rejected() {
+              label=$1
+              filter=$2
+              jq "$filter" valid-manifest.json > "$manifest"
+              if HOMELAB_APPCTL_METADATA_ROOT="$metadata_root" \
+                HOMELAB_APPCTL_STATE_ROOT="$state_root" \
+                HOMELAB_APPCTL_TEST_ALLOW_FILE_URL=1 \
+                homelab-appctl deploy deopjib dev --target "$target" --dry-run >/dev/null 2>&1; then
+                echo "release dry-run accepted invalid manifest: $label" >&2
+                exit 1
+              fi
+            }
+
+            expect_rejected schema-version '.schemaVersion = 2'
+            expect_rejected target '.target = "deopjib-v0.0.0-dev.1111111"'
+            expect_rejected runtime-hash '.deploymentContract.runtimeSourceSha256 = ("0" * 64)'
+            expect_rejected admission-hash '.deploymentContract.admissionSourceSha256 = ("0" * 64)'
+            expect_rejected schema-hash '.deploymentContract.schemaSourceSha256 = ("0" * 64)'
+            expect_rejected generator-hash '.deploymentContract.generatorSourceSha256 = ("0" * 64)'
+            expect_rejected backend-name '.images.backend.name = "ghcr.io/rjcnd105/not-admitted"'
+            expect_rejected backend-digest '.images.backend.digest = "sha256:not-a-digest"'
+
+            cp dry-run.out "$out"
+          '';
+
+      homelabAppctlReleaseTransaction =
+        let
+          inherit (homelabAppctlTestContext)
+            appctl
+            metadata
+            pkgs
+            releaseManifest
+            ;
+        in
+        pkgs.runCommand "homelab-appctl-release-transaction"
+          {
+            nativeBuildInputs = [
+              appctl
+              pkgs.coreutils
+              pkgs.gawk
+              pkgs.gnugrep
+              pkgs.jq
+              pkgs.util-linux
+            ];
+          }
+          ''
+            set -euo pipefail
+
+            target=deopjib-v0.0.0-dev.0000000
+            metadata_root="$PWD/metadata"
+            state_root="$PWD/state"
+            image_state="$PWD/images"
+            export HOMELAB_APPCTL_METADATA_ROOT="$metadata_root"
+            export HOMELAB_APPCTL_STATE_ROOT="$state_root"
+            export HOMELAB_APPCTL_TEST_LOG="$PWD/commands.log"
+            export HOMELAB_APPCTL_TEST_MANIFEST=${releaseManifest}
+            export HOMELAB_APPCTL_TEST_IMAGE_STATE="$image_state"
+            export HOMELAB_APPCTL_TEST_FAIL_MARKER="$PWD/migration-failed"
+            export HOMELAB_APPCTL_TEST_FAIL_MIGRATION=0
+            export HOMELAB_APPCTL_TEST_FAIL_RESTORE=0
+            mkdir -p "$metadata_root/deopjib" "$state_root" "$image_state"
+            : > "$HOMELAB_APPCTL_TEST_LOG"
+            printf '%s\n' backend-old > "$image_state/backend"
+            printf '%s\n' web-old > "$image_state/web"
+
+            jq --arg manifestUrl 'https://fixture.invalid/{target}/release.json' \
+              '.release.manifestUrl = $manifestUrl' \
+              ${metadata} > "$metadata_root/deopjib/dev.json"
+
+            id() {
+              if [ "$1" = -u ]; then
+                printf '0\n'
+                return 0
+              fi
+              command id "$@"
+            }
+
+            curl() {
+              printf 'curl\t%s\n' "$*" >> "$HOMELAB_APPCTL_TEST_LOG"
+              local output="" url="" requested_target version
+              while [ "$#" -gt 0 ]; do
+                case "$1" in
+                  -o)
+                    output=$2
+                    shift 2
+                    ;;
+                  https://*)
+                    url=$1
+                    shift
+                    ;;
+                  *) shift ;;
+                esac
+              done
+              if [ -n "$output" ]; then
+                requested_target=$(printf '%s\n' "$url" | cut -d/ -f4)
+                version="''${requested_target#deopjib-v}"
+                jq --arg target "$requested_target" --arg version "$version" '
+                  .target = $target
+                  | .version = $version
+                  | if $target == "deopjib-v1.0.1" or $target == "deopjib-v1.0.2"
+                    then .images.backend.digest = ("c" * 64 | "sha256:" + .)
+                      | .images.web.digest = ("d" * 64 | "sha256:" + .)
+                    else . end
+                ' "$HOMELAB_APPCTL_TEST_MANIFEST" > "$output"
+              fi
+            }
+
+            podman() {
+              printf 'podman\t%s\n' "$*" >> "$HOMELAB_APPCTL_TEST_LOG"
+              case "$1" in
+                image)
+                  case "$3" in
+                    *deopjib-backend:dev-current) cat "$HOMELAB_APPCTL_TEST_IMAGE_STATE/backend" ;;
+                    *deopjib-web:dev-current) cat "$HOMELAB_APPCTL_TEST_IMAGE_STATE/web" ;;
+                    *) printf 'db-pinned\n' ;;
+                  esac
+                  ;;
+                pull) ;;
+                tag)
+                  if [ "$HOMELAB_APPCTL_TEST_FAIL_RESTORE" = 1 ] \
+                    && [ -e "$HOMELAB_APPCTL_TEST_FAIL_MARKER" ]; then
+                    return 1
+                  fi
+                  case "$3" in
+                    *deopjib-backend:dev-current) printf '%s\n' "$2" > "$HOMELAB_APPCTL_TEST_IMAGE_STATE/backend" ;;
+                    *deopjib-web:dev-current) printf '%s\n' "$2" > "$HOMELAB_APPCTL_TEST_IMAGE_STATE/web" ;;
+                    *) return 1 ;;
+                  esac
+                  ;;
+                untag)
+                  case "$2" in
+                    *deopjib-backend:dev-current) : > "$HOMELAB_APPCTL_TEST_IMAGE_STATE/backend" ;;
+                    *deopjib-web:dev-current) : > "$HOMELAB_APPCTL_TEST_IMAGE_STATE/web" ;;
+                  esac
+                  ;;
+                *) return 1 ;;
+              esac
+            }
+
+            systemctl() {
+              printf 'systemctl\t%s\n' "$*" >> "$HOMELAB_APPCTL_TEST_LOG"
+              if [ "$1" = start ] && [ "$HOMELAB_APPCTL_TEST_FAIL_MIGRATION" = 1 ]; then
+                touch "$HOMELAB_APPCTL_TEST_FAIL_MARKER"
+                return 1
+              fi
+              if [ "$1" = restart ]; then
+                printf 'restart-begin\t%s\n' "$BASHPID" >> "$HOMELAB_APPCTL_TEST_LOG"
+                sleep 0.2
+                printf 'restart-end\t%s\n' "$BASHPID" >> "$HOMELAB_APPCTL_TEST_LOG"
+              fi
+            }
+
+            export -f id curl podman systemctl
+
+            homelab-appctl deploy deopjib dev --target "$target"
+            latest="$state_root/deopjib/dev/latest"
+            [ "$(cat "$latest/result")" = ok ]
+            [ "$(grep -c '^systemctl[[:space:]]restart' "$HOMELAB_APPCTL_TEST_LOG")" -eq 1 ]
+            grep -F $'systemctl\trestart deopjib-dev-backend.service deopjib-dev-web.service' "$HOMELAB_APPCTL_TEST_LOG" >/dev/null
+            if grep -E '^systemctl[[:space:]]restart .*deopjib-dev-db.service' "$HOMELAB_APPCTL_TEST_LOG" >/dev/null; then
+              echo 'release transaction restarted PostgreSQL' >&2
+              exit 1
+            fi
+            [ "$(grep -c '^systemctl[[:space:]]start deopjib-dev-migrate.service' "$HOMELAB_APPCTL_TEST_LOG")" -eq 1 ]
+            [ "$(grep -c '^podman[[:space:]]pull ' "$HOMELAB_APPCTL_TEST_LOG")" -eq 2 ]
+
+            cp "$HOMELAB_APPCTL_TEST_LOG" before-noop.log
+            homelab-appctl deploy deopjib dev --target "$target"
+            cmp before-noop.log "$HOMELAB_APPCTL_TEST_LOG"
+
+            printf '%s\n' in-progress > "$latest/result"
+            homelab-appctl deploy deopjib dev --target "$target"
+            [ "$(grep -c '^systemctl[[:space:]]restart' "$HOMELAB_APPCTL_TEST_LOG")" -eq 2 ]
+
+            jq '.caddyUrl = "http://127.0.0.1:19999"' "$metadata_root/deopjib/dev.json" > metadata.json
+            mv metadata.json "$metadata_root/deopjib/dev.json"
+            homelab-appctl deploy deopjib dev --target "$target"
+            [ "$(grep -c '^systemctl[[:space:]]restart' "$HOMELAB_APPCTL_TEST_LOG")" -eq 3 ]
+
+            previous_backend=$(cat "$image_state/backend")
+            previous_web=$(cat "$image_state/web")
+            if HOMELAB_APPCTL_TEST_FAIL_MIGRATION=1 \
+              homelab-appctl deploy deopjib dev --target deopjib-v1.0.1; then
+              echo 'migration failure unexpectedly succeeded' >&2
+              exit 1
+            fi
+            [ "$(cat "$latest/result")" = migration-failed ]
+            [ "$(cat "$image_state/backend")" = "$previous_backend" ]
+            [ "$(cat "$image_state/web")" = "$previous_web" ]
+
+            rm -f "$HOMELAB_APPCTL_TEST_FAIL_MARKER"
+            if HOMELAB_APPCTL_TEST_FAIL_MIGRATION=1 HOMELAB_APPCTL_TEST_FAIL_RESTORE=1 \
+              homelab-appctl deploy deopjib dev --target deopjib-v1.0.2; then
+              echo 'recovery failure unexpectedly succeeded' >&2
+              exit 1
+            fi
+            [ "$(cat "$latest/result")" = migration-recovery-failed ]
+
+            rm -f "$HOMELAB_APPCTL_TEST_FAIL_MARKER"
+            HOMELAB_APPCTL_TEST_FAIL_MIGRATION=0 HOMELAB_APPCTL_TEST_FAIL_RESTORE=0 \
+              homelab-appctl deploy deopjib dev --target deopjib-v1.0.3 &
+            first_pid=$!
+            HOMELAB_APPCTL_TEST_FAIL_MIGRATION=0 HOMELAB_APPCTL_TEST_FAIL_RESTORE=0 \
+              homelab-appctl deploy deopjib dev --target deopjib-v1.0.4 &
+            second_pid=$!
+            wait "$first_pid"
+            wait "$second_pid"
+
+            awk '
+              /^restart-begin/ { if (active) exit 1; active = 1 }
+              /^restart-end/ { if (!active) exit 1; active = 0 }
+              END { if (active) exit 1 }
+            ' "$HOMELAB_APPCTL_TEST_LOG"
+
+            cp "$HOMELAB_APPCTL_TEST_LOG" "$out"
+          '';
 
       homelabQuadletLifecycleInvariants =
         let
@@ -191,6 +515,9 @@
           ];
           podman = homelab.virtualisation.podman.package;
           pkgs = pkgsFor "x86_64-linux";
+          backendContainer = quadlet.containers.deopjib-dev-backend;
+          dbContainer = quadlet.containers.deopjib-dev-db;
+          deopjibImages = lib.filterAttrs (name: _: lib.hasPrefix "deopjib-dev-" name) quadlet.images;
           networkText = builtins.unsafeDiscardStringContext network._configText;
           podmanPath = builtins.unsafeDiscardStringContext "${podman}";
           deopjibContainers = builtins.attrValues (
@@ -225,6 +552,15 @@
         assert network.networkConfig.name == "deopjib-dev";
         assert network.networkConfig.interfaceName == "br-deopjib-dev";
         assert builtins.elem 53 homelab.networking.firewall.interfaces.br-deopjib-dev.allowedUDPPorts;
+        assert builtins.attrNames deopjibImages == [ "deopjib-dev-db" ];
+        assert backendContainer.containerConfig.image == "ghcr.io/rjcnd105/deopjib-backend:dev-current";
+        assert backendContainer.containerConfig.pull == "never";
+        assert builtins.elem "deopjib-dev-db.service" backendContainer.unitConfig.Requires;
+        assert builtins.elem "deopjib-dev-db.service" backendContainer.unitConfig.After;
+        assert dbContainer.containerConfig.notify == "healthy";
+        assert dbContainer.containerConfig.healthInterval == "1s";
+        assert dbContainer.containerConfig.healthRetries == 30;
+        assert dbContainer.containerConfig.healthTimeout == "5s";
         assert builtins.all (
           container:
           builtins.elem networkService container.unitConfig.PartOf
@@ -251,6 +587,9 @@
           ${pkgs.gnugrep}/bin/grep -F '${dnsLifecycleService}' generated-units.txt >/dev/null
           ${pkgs.gnugrep}/bin/grep -F 'Requires=${networkService}' generated-units.txt >/dev/null
           ${pkgs.gnugrep}/bin/grep -F 'After=${networkService}' generated-units.txt >/dev/null
+          ${pkgs.gnugrep}/bin/grep -F 'Requires=deopjib-dev-db.service' generated-units.txt >/dev/null
+          ${pkgs.gnugrep}/bin/grep -F 'Notify=healthy' generated-units.txt >/dev/null
+          ${pkgs.gnugrep}/bin/grep -F 'HealthInterval=1s' generated-units.txt >/dev/null
           ${pkgs.gnugrep}/bin/grep -F 'ExecStop=${podman}/bin/podman network rm deopjib-dev' generated-units.txt >/dev/null
           ${pkgs.gnugrep}/bin/grep -F -- '--interface-name br-deopjib-dev' generated-units.txt >/dev/null
           ${pkgs.gnugrep}/bin/grep -F -- '--disable-dns hindsight-db' generated-units.txt >/dev/null
@@ -404,6 +743,8 @@
           });
         in
         lib.recursiveUpdate baseChecks {
+          x86_64-linux.homelab-appctl-release-dry-run = homelabAppctlReleaseDryRun;
+          x86_64-linux.homelab-appctl-release-transaction = homelabAppctlReleaseTransaction;
           x86_64-linux.homelab-quadlet-lifecycle-invariants = homelabQuadletLifecycleInvariants;
         };
 

--- a/rules/repo-policy.md
+++ b/rules/repo-policy.md
@@ -32,7 +32,9 @@ Nix guidance.
 - Do not copy app-specific runtime shape from chat into `nix-dots` when the app
   repo can own a contract.
 - Do not add app-specific homelab deploy scripts to app repos.
-- OCI release manifests may exist for audit, but are not the deploy ABI.
+- `manual` services deploy the exact image digests in an app release manifest.
+  `nix-dots` admits its image names, target channel, and runtime, admission,
+  manifest-schema, and generator source hashes before any host mutation.
 
 ## Homelab Deploy ABI
 
@@ -44,7 +46,6 @@ homelab-appctl status <app> <channel>
 homelab-appctl smoke <app> <channel>
 homelab-appctl deploy <app> <channel> --dry-run --target <identifier>
 sudo -n homelab-appctl deploy <app> <channel> --target <identifier>
-sudo -n homelab-appctl rollback <app> <channel>
 ```
 
 `homelab-appctl` reads generated metadata from:
@@ -54,16 +55,19 @@ sudo -n homelab-appctl rollback <app> <channel>
 ```
 
 Do not make the app repo depend on this path. This path is a host adapter detail.
-`deploy` and `rollback` require root because they write deploy records and
-control system services; this repo grants only those subcommands through a
-narrow passwordless sudo rule for the homelab operator user.
+`deploy` requires root because it writes deploy records and controls system
+services; this repo grants only that subcommand through a narrow passwordless
+sudo rule for the homelab operator user. A rollback within the admitted source
+hashes is another deploy of a known-good target; older contracts first require a
+pinned app-input revert through PR/comin.
 
 When `deploy` receives `--target <identifier>`, it compares that identifier
 with the most recent deploy record. Prefer app release identifiers such as
 `deopjib-v0.0.1`; full source SHAs are a transition format. Matching targets are
-no-ops only when the most recent record is successful; newer failed records
-allow retry. Different targets run the normal pull, migration, restart, smoke,
-and record sequence.
+no-ops only when the most recent record is successful and its admitted metadata
+is byte-identical; newer failed records or changed metadata allow retry.
+Different targets validate the release manifest and deployment source hashes, pull exact
+digests, migrate, restart release-managed services once, smoke, and record.
 
 External app repos may dispatch `.github/workflows/deploy-homelab-app.yml`, but
 the workflow must stay host-owned, input-validated, and homelab-runner-only. Do

--- a/systems/homelab/app-admissions.nix
+++ b/systems/homelab/app-admissions.nix
@@ -1,7 +1,19 @@
 { inputs, ... }:
 let
-  deopjibAdmission = import "${inputs.deopjibRuntime}/deopjib/devops/homelab-admission.nix";
+  deopjibAdmissionSource = "${inputs.deopjibRuntime}/deopjib/devops/homelab-admission.nix";
+  deopjibRuntimeContractSource = "${inputs.deopjibRuntime}/deopjib/devops/runtime-contract.nix";
+  deopjibManifestSchemaSource = "${inputs.deopjibRuntime}/deopjib/devops/release-manifest.schema.json";
+  deopjibManifestGeneratorSource = "${inputs.deopjibRuntime}/scripts/deopjib-generate-release-manifest";
+  deopjibAdmission = import deopjibAdmissionSource;
 in
 {
-  homelab.apps.${deopjibAdmission.key} = deopjibAdmission.app;
+  homelab.apps.${deopjibAdmission.key} = deopjibAdmission.app // {
+    runtimeContractSourceSha256 = builtins.hashFile "sha256" deopjibRuntimeContractSource;
+    homelabAdmissionSourceSha256 = builtins.hashFile "sha256" deopjibAdmissionSource;
+    manifestSchemaSourceSha256 = builtins.hashFile "sha256" deopjibManifestSchemaSource;
+    manifestGeneratorSourceSha256 = builtins.hashFile "sha256" deopjibManifestGeneratorSource;
+    host = deopjibAdmission.app.host // {
+      releaseManifestOrigins = [ "https://github.com/rjcnd105/my-app" ];
+    };
+  };
 }

--- a/systems/homelab/app-containers.nix
+++ b/systems/homelab/app-containers.nix
@@ -70,6 +70,8 @@ let
     else
       "invalid-image-reference";
 
+  releaseManaged = service: service.updatePolicy == "manual";
+
   envTemplateNameFor = app: serviceName: "${unitPrefixFor app}-${serviceName}.env";
 
   releaseChannelFor =
@@ -78,6 +80,14 @@ let
       app.contract.release.channels.${app.contract.channel}
     else
       null;
+
+  releaseImageNameFor =
+    app: service:
+    let
+      imageRef = imageRefFor app service;
+      releaseChannel = releaseChannelFor app;
+    in
+    if releaseChannel == null then imageRef else lib.removeSuffix ":${releaseChannel.tag}" imageRef;
 
   smokePathsFor =
     app:
@@ -227,6 +237,7 @@ let
       authFile = registryAuthFileFor app;
       envTemplate = config.sops.templates.${envTemplateNameFor app serviceName}.path;
       networkService = "${unitPrefix}-network.service";
+      dependencyServices = map (name: "${unitPrefix}-${name}.service") service.dependsOn;
       volumes = map (mount: mountLineFor app mount) service.volumeMounts;
     in
     nameValuePair "${unitPrefix}-${serviceName}" {
@@ -235,11 +246,13 @@ let
         Requires = [
           "sops-install-secrets.service"
           podmanDnsLifecycleService
-        ];
+        ]
+        ++ dependencyServices;
         After = [
           "sops-install-secrets.service"
           podmanDnsLifecycleService
-        ];
+        ]
+        ++ dependencyServices;
         PartOf = [
           networkService
           podmanDnsLifecycleService
@@ -247,7 +260,8 @@ let
       };
       containerConfig = {
         name = "${unitPrefix}-${serviceName}";
-        image = "${unitPrefix}-${serviceName}.image";
+        image =
+          if releaseManaged service then imageRefFor app service else "${unitPrefix}-${serviceName}.image";
         pull = "never";
         autoUpdate = if service.updatePolicy == "registry-auto" then "registry" else null;
         labels = lib.optionalAttrs (service.updatePolicy == "registry-auto" && authFile != null) {
@@ -261,6 +275,13 @@ let
           "127.0.0.1:${toString servicePorts.${serviceName}}:${toString service.internalPort}"
         ];
         inherit volumes;
+      }
+      // lib.optionalAttrs (service.readiness != null) {
+        healthCmd = lib.escapeShellArgs service.readiness.command;
+        healthInterval = service.readiness.interval;
+        healthRetries = service.readiness.retries;
+        healthTimeout = service.readiness.timeout;
+        notify = "healthy";
       };
       serviceConfig = {
         Restart = "on-failure";
@@ -299,6 +320,7 @@ let
       imageRef = imageRefFor app service;
       networkService = "${unitPrefix}-network.service";
       imageService = "${unitPrefix}-${migrationServiceName}-image.service";
+      dependencyServices = map (name: "${unitPrefix}-${name}.service") service.dependsOn;
       volumeServices = map (mount: "${unitPrefix}-${mount.volume}-volume.service") service.volumeMounts;
       volumeArgs = concatStringsSep " " (
         map (mount: "--volume ${lib.escapeShellArg (podmanMountLineFor app mount)}") service.volumeMounts
@@ -310,15 +332,17 @@ let
         "sops-install-secrets.service"
         "network-online.target"
         networkService
-        imageService
       ]
+      ++ lib.optional (!releaseManaged service) imageService
+      ++ dependencyServices
       ++ volumeServices;
       after = [
         "sops-install-secrets.service"
         "network-online.target"
         networkService
-        imageService
       ]
+      ++ lib.optional (!releaseManaged service) imageService
+      ++ dependencyServices
       ++ volumeServices;
       serviceConfig.Type = "oneshot";
       script = ''
@@ -343,12 +367,15 @@ let
       name = serviceName;
       imageKey = service.image;
       imageRef = imageRefFor app service;
-      imageUnit = "${unitPrefix}-${serviceName}-image.service";
+      imageName = if releaseManaged service then releaseImageNameFor app service else null;
+      imageUnit = if releaseManaged service then null else "${unitPrefix}-${serviceName}-image.service";
+      releaseManaged = releaseManaged service;
       serviceUnit = "${unitPrefix}-${serviceName}.service";
       containerName = "${unitPrefix}-${serviceName}";
       internalPort = service.internalPort;
       loopbackPort = servicePorts.${serviceName};
       healthPath = service.healthPath;
+      dependsOn = service.dependsOn;
       updatePolicy = service.updatePolicy;
     };
 
@@ -363,9 +390,14 @@ let
       appKey = appName;
       name = app.contract.name;
       channel = app.contract.channel;
+      runtimeContractSourceSha256 = app.runtimeContractSourceSha256;
+      homelabAdmissionSourceSha256 = app.homelabAdmissionSourceSha256;
+      manifestSchemaSourceSha256 = app.manifestSchemaSourceSha256;
+      manifestGeneratorSourceSha256 = app.manifestGeneratorSourceSha256;
       unitPrefix = unitPrefix;
       domain = app.host.domain;
       caddyUrl = "http://127.0.0.1:${toString caddyPort}";
+      registryAuthFile = registryAuthFileFor app;
       smokePaths = smokePathsFor app;
       services = mapAttrsToList (serviceMetadataFor app) app.contract.services;
       migration =
@@ -388,11 +420,12 @@ let
           null
         else
           {
+            manifestUrl = app.contract.release.manifestUrl;
             tag = releaseChannel.tag;
             mode = releaseChannel.mode;
+            targetPattern = releaseChannel.targetPattern;
             strategy = releaseChannel.strategy;
             migrate = releaseChannel.migrate;
-            rollback = releaseChannel.rollback;
             smokePaths = releaseChannel.smokePaths;
           };
     };
@@ -415,7 +448,10 @@ let
   quadletImages = listToAttrs (
     flatten (
       mapAttrsToList (
-        _appName: app: mapAttrsToList (quadletImageFor app) app.contract.services
+        _appName: app:
+        mapAttrsToList (quadletImageFor app) (
+          filterAttrs (_serviceName: service: !releaseManaged service) app.contract.services
+        )
       ) enabledApps
     )
   );
@@ -433,15 +469,17 @@ let
       pkgs.curl
       pkgs.findutils
       pkgs.gnugrep
+      pkgs.gnused
       pkgs.jq
       pkgs.podman
       pkgs.systemd
+      pkgs.util-linux
     ];
     text = ''
       set -euo pipefail
 
-      metadata_root=/etc/homelab-apps
-      state_root=/var/lib/homelab-appctl
+      metadata_root="''${HOMELAB_APPCTL_METADATA_ROOT:-/etc/homelab-apps}"
+      state_root="''${HOMELAB_APPCTL_STATE_ROOT:-/var/lib/homelab-appctl}"
 
       usage() {
         cat <<'EOF'
@@ -449,8 +487,7 @@ let
         homelab-appctl list
         homelab-appctl status <app> <channel>
         homelab-appctl smoke <app> <channel>
-        homelab-appctl deploy <app> <channel> [--dry-run] [--target <identifier>]
-        homelab-appctl rollback <app> <channel>
+        homelab-appctl deploy <app> <channel> --target <release-id> [--dry-run]
         homelab-appctl logs <app> <channel>
       EOF
       }
@@ -469,8 +506,8 @@ let
 
       require_target() {
         local value=$1
-        [[ "$value" =~ ^[A-Za-z0-9._:-]+$ ]] ||
-          die "target must match ^[A-Za-z0-9._:-]+$: $value"
+        [[ "$value" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] ||
+          die "target must match ^[A-Za-z0-9][A-Za-z0-9._-]*$: $value"
       }
 
       require_app_channel() {
@@ -506,8 +543,12 @@ let
         jq -r '.services[].serviceUnit' "$1"
       }
 
-      image_units() {
-        jq -r '.services[].imageUnit' "$1"
+      release_units() {
+        jq -r '.services[] | select(.releaseManaged) | .serviceUnit' "$1"
+      }
+
+      release_images() {
+        jq -r '.services[] | select(.releaseManaged) | [.name, .imageKey, .imageName, .imageRef] | @tsv' "$1"
       }
 
       smoke_paths() {
@@ -596,13 +637,177 @@ let
         ln -sfnT "$record_path" "$record_dir/latest"
       }
 
+      begin_record() {
+        local record_dir=$1
+        local record_path=$2
+        local app=$3
+        local channel=$4
+        local target=$5
+        local migration_result=$6
+        local smoke_result=$7
+
+        printf '%s\n' in-progress > "$record_path/result"
+        write_record_summary "$record_path" "$app" "$channel" "$target" in-progress "$migration_result" "$smoke_result"
+        ln -sfnT "$record_path" "$record_dir/latest"
+      }
+
       current_target() {
         local app=$1
         local channel=$2
+        local meta=$3
         local latest="$state_root/$app/$channel/latest"
-        if [ -e "$latest/target" ] && [ -e "$latest/result" ] && [ "$(cat "$latest/result")" = ok ]; then
+        if [ -e "$latest/target" ] \
+          && [ -e "$latest/result" ] \
+          && [ "$(cat "$latest/result")" = ok ] \
+          && cmp -s "$meta" "$latest/metadata.json"; then
           cat "$latest/target"
         fi
+      }
+
+      manifest_url() {
+        local meta=$1
+        local target=$2
+        local template
+        template=$(jq -er '.release.manifestUrl | strings' "$meta")
+        [[ "$template" == *'{target}'* ]] || die "release manifest URL is missing {target}: $template"
+        printf '%s\n' "''${template//\{target\}/$target}"
+      }
+
+      download_manifest() {
+        local url=$1
+        local output=$2
+
+        case "$url" in
+          https://*)
+            curl -fsSL --proto '=https' --proto-redir '=https' \
+              --retry 3 --connect-timeout 5 --max-time 30 "$url" -o "$output"
+            ;;
+          file://*)
+            if [ "''${HOMELAB_APPCTL_TEST_ALLOW_FILE_URL:-0}" = 1 ] \
+              && [ "$(id -u)" -ne 0 ] \
+              && [ "$metadata_root" != /etc/homelab-apps ] \
+              && [ "$state_root" != /var/lib/homelab-appctl ]; then
+              curl -fsSL --proto '=file' --proto-redir '=file' "$url" -o "$output"
+            else
+              echo "release manifest URL must use HTTPS: $url" >&2
+              return 1
+            fi
+            ;;
+          *)
+            echo "release manifest URL must use HTTPS: $url" >&2
+            return 1
+            ;;
+        esac
+      }
+
+      validate_manifest() {
+        local meta=$1
+        local manifest=$2
+        local target=$3
+        local app target_pattern runtime_contract_hash homelab_admission_hash manifest_schema_hash manifest_generator_hash
+        app=$(jq -r '.name' "$meta")
+        target_pattern=$(jq -er '.release.targetPattern | strings' "$meta")
+        runtime_contract_hash=$(jq -r '.runtimeContractSourceSha256' "$meta")
+        homelab_admission_hash=$(jq -r '.homelabAdmissionSourceSha256' "$meta")
+        manifest_schema_hash=$(jq -r '.manifestSchemaSourceSha256' "$meta")
+        manifest_generator_hash=$(jq -r '.manifestGeneratorSourceSha256' "$meta")
+
+        jq -e \
+          --arg app "$app" \
+          --arg target "$target" \
+          --arg targetPattern "$target_pattern" \
+          --arg runtimeContractHash "$runtime_contract_hash" \
+          --arg homelabAdmissionHash "$homelab_admission_hash" \
+          --arg manifestSchemaHash "$manifest_schema_hash" \
+          --arg manifestGeneratorHash "$manifest_generator_hash" \
+          '.schemaVersion == 1
+            and .app == $app
+            and .target == $target
+            and (.target | test($targetPattern))
+            and (.sourceRev | test("^[0-9a-f]{40}$"))
+            and .deploymentContract.runtimeSourceSha256 == $runtimeContractHash
+            and .deploymentContract.admissionSourceSha256 == $homelabAdmissionHash
+            and .deploymentContract.schemaSourceSha256 == $manifestSchemaHash
+            and .deploymentContract.generatorSourceSha256 == $manifestGeneratorHash' \
+          "$manifest" >/dev/null
+      }
+
+      desired_images() {
+        local meta=$1
+        local manifest=$2
+        local service image_key image_name image_ref manifest_name digest
+
+        while IFS=$'\t' read -r service image_key image_name image_ref; do
+          manifest_name=$(jq -er --arg key "$image_key" '.images[$key].name | strings' "$manifest") || return 1
+          digest=$(jq -er --arg key "$image_key" '.images[$key].digest | strings' "$manifest") || return 1
+          if [ "$manifest_name" != "$image_name" ]; then
+            echo "manifest image name mismatch for $service: $manifest_name" >&2
+            return 1
+          fi
+          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "invalid manifest digest for $service: $digest" >&2
+            return 1
+          fi
+          printf '%s\t%s\t%s\t%s\n' "$service" "$image_ref" "$manifest_name" "$digest"
+        done < <(release_images "$meta")
+      }
+
+      pull_release_images() {
+        local meta=$1
+        local desired=$2
+        local auth_file service image_ref image_name digest
+        local auth_args=()
+        auth_file=$(jq -r '.registryAuthFile // empty' "$meta")
+        if [ -n "$auth_file" ]; then
+          auth_args=(--authfile "$auth_file")
+        fi
+
+        while IFS=$'\t' read -r service image_ref image_name digest; do
+          echo "pull: $image_name@$digest"
+          podman pull "''${auth_args[@]}" "$image_name@$digest" >/dev/null || return 1
+        done < "$desired"
+      }
+
+      activate_release_images() {
+        local desired=$1
+        local service image_ref image_name digest
+        while IFS=$'\t' read -r service image_ref image_name digest; do
+          echo "activate: $image_ref -> $digest"
+          podman tag "$image_name@$digest" "$image_ref" || return 1
+        done < "$desired"
+      }
+
+      restore_release_images() {
+        local desired=$1
+        local before=$2
+        local service image_ref image_name digest before_ref before_id previous_id
+        local failed=0
+
+        while IFS=$'\t' read -r service image_ref image_name digest; do
+          previous_id=""
+          while IFS=$'\t' read -r _ before_ref before_id; do
+            if [ "$before_ref" = "$image_ref" ]; then
+              previous_id=$before_id
+              break
+            fi
+          done < "$before"
+
+          if [ -n "$previous_id" ]; then
+            if ! podman tag "$previous_id" "$image_ref"; then
+              echo "failed to restore $image_ref to $previous_id" >&2
+              failed=1
+            fi
+          else
+            if ! podman untag "$image_ref" >/dev/null 2>&1; then
+              if podman image inspect "$image_ref" >/dev/null 2>&1; then
+                echo "failed to remove newly activated tag $image_ref" >&2
+                failed=1
+              fi
+            fi
+          fi
+        done < "$desired"
+
+        return "$failed"
       }
 
       cmd_list() {
@@ -665,14 +870,17 @@ let
         local meta=$3
         local dry_run=$4
         local target=$5
-        local current
-        local migration_unit record_dir record_path
-        local migration_result smoke_result image_unit service_unit
-
-        migration_unit=$(jq -r '.migration.unit // empty' "$meta")
-        current=$(current_target "$app" "$channel" 2>/dev/null || true)
+        local current release_manifest_url
+        local migration_unit record_dir record_path deploy_lock_fd metadata_snapshot
+        local migration_result smoke_result result
+        local release_service_units=()
 
         if [ "$dry_run" = 1 ]; then
+          local dry_run_dir
+          migration_unit=$(jq -r '.migration.unit // empty' "$meta")
+          current=$(current_target "$app" "$channel" "$meta" 2>/dev/null || true)
+          release_manifest_url=$(manifest_url "$meta" "$target")
+          dry_run_dir=$(mktemp -d)
           echo "metadata: $meta"
           if [ -n "$target" ]; then
             echo "target: $target"
@@ -682,55 +890,108 @@ let
               echo "action: deploy; current target: ''${current:-none}"
             fi
           fi
-          echo "image units:"
-          image_units "$meta" | sed 's/^/  /'
+          echo "release manifest: $release_manifest_url"
+          if ! download_manifest "$release_manifest_url" "$dry_run_dir/release-manifest.json"; then
+            rm -rf "$dry_run_dir"
+            die "release manifest download failed: $release_manifest_url"
+          fi
+          if ! validate_manifest "$meta" "$dry_run_dir/release-manifest.json" "$target"; then
+            rm -rf "$dry_run_dir"
+            die "release manifest does not match admitted metadata: $target"
+          fi
+          if ! desired_images "$meta" "$dry_run_dir/release-manifest.json" > "$dry_run_dir/desired-images.tsv" \
+            || [ ! -s "$dry_run_dir/desired-images.tsv" ]; then
+            rm -rf "$dry_run_dir"
+            die "release manifest has no valid admitted images"
+          fi
+          echo "release images:"
+          while IFS=$'\t' read -r _ image_ref image_name digest; do
+            echo "  $image_name@$digest -> $image_ref"
+          done < "$dry_run_dir/desired-images.tsv"
           if [ -n "$migration_unit" ]; then
             echo "migration unit:"
             echo "  $migration_unit"
           else
             echo "migration unit: none"
           fi
-          echo "service units:"
-          service_units "$meta" | sed 's/^/  /'
+          echo "release service units:"
+          release_units "$meta" | sed 's/^/  /'
           echo "smoke paths:"
           smoke_paths "$meta" | sed 's/^/  /'
+          rm -rf "$dry_run_dir"
           return 0
         fi
 
         require_root deploy "$app" "$channel"
 
+        record_dir="$state_root/$app/$channel"
+        mkdir -p "$record_dir"
+        exec {deploy_lock_fd}> "$record_dir/deploy.lock"
+        flock -w 900 "$deploy_lock_fd" || die "timed out waiting for deploy lock: $app/$channel"
+
+        metadata_snapshot=$(mktemp)
+        cp "$meta" "$metadata_snapshot"
+        meta="$metadata_snapshot"
+        current=$(current_target "$app" "$channel" "$meta" 2>/dev/null || true)
+
         if [ -n "$target" ] && [ "$current" = "$target" ]; then
           echo "target already deployed: $target"
+          rm -f "$metadata_snapshot"
           return 0
         fi
 
-        record_dir="$state_root/$app/$channel"
-        record_path="$record_dir/$(date -u +%Y%m%dT%H%M%SZ)"
-        mkdir -p "$record_path"
+        record_path=$(mktemp -d "$record_dir/$(date -u +%Y%m%dT%H%M%SZ).XXXXXX")
         cp "$meta" "$record_path/metadata.json"
+        rm -f "$metadata_snapshot"
+        meta="$record_path/metadata.json"
         sha256sum "$meta" > "$record_path/metadata.sha256"
         if [ -n "$target" ]; then
           printf '%s\n' "$target" > "$record_path/target"
         fi
+        migration_unit=$(jq -r '.migration.unit // empty' "$meta")
+        release_manifest_url=$(manifest_url "$meta" "$target")
         migration_result=skipped
         if [ -n "$migration_unit" ]; then
           migration_result=not-run
         fi
         smoke_result=not-run
         snapshot_images "$meta" > "$record_path/before-images.tsv"
+        begin_record "$record_dir" "$record_path" "$app" "$channel" "$target" "$migration_result" "$smoke_result"
 
-        if ! systemctl daemon-reload; then
-          finish_record "$record_dir" "$record_path" "$app" "$channel" "$target" restart-failed "$migration_result" "$smoke_result"
+        echo "manifest: $release_manifest_url"
+        if ! download_manifest "$release_manifest_url" "$record_path/release-manifest.json"; then
+          finish_record "$record_dir" "$record_path" "$app" "$channel" "$target" manifest-download-failed "$migration_result" "$smoke_result"
           return 1
         fi
 
-        while IFS= read -r image_unit; do
-          echo "pull: $image_unit"
-          if ! systemctl restart "$image_unit"; then
-            finish_record "$record_dir" "$record_path" "$app" "$channel" "$target" pull-failed "$migration_result" "$smoke_result"
-            return 1
+        if ! validate_manifest "$meta" "$record_path/release-manifest.json" "$target"; then
+          finish_record "$record_dir" "$record_path" "$app" "$channel" "$target" manifest-invalid "$migration_result" "$smoke_result"
+          return 1
+        fi
+
+        if ! desired_images "$meta" "$record_path/release-manifest.json" > "$record_path/desired-images.tsv"; then
+          finish_record "$record_dir" "$record_path" "$app" "$channel" "$target" manifest-invalid "$migration_result" "$smoke_result"
+          return 1
+        fi
+        if [ ! -s "$record_path/desired-images.tsv" ]; then
+          finish_record "$record_dir" "$record_path" "$app" "$channel" "$target" manifest-invalid "$migration_result" "$smoke_result"
+          return 1
+        fi
+
+        if ! pull_release_images "$meta" "$record_path/desired-images.tsv"; then
+          finish_record "$record_dir" "$record_path" "$app" "$channel" "$target" pull-failed "$migration_result" "$smoke_result"
+          return 1
+        fi
+
+        if ! activate_release_images "$record_path/desired-images.tsv"; then
+          if restore_release_images "$record_path/desired-images.tsv" "$record_path/before-images.tsv"; then
+            result=activation-failed
+          else
+            result=activation-recovery-failed
           fi
-        done < <(image_units "$meta")
+          finish_record "$record_dir" "$record_path" "$app" "$channel" "$target" "$result" "$migration_result" "$smoke_result"
+          return 1
+        fi
 
         if [ -n "$migration_unit" ]; then
           echo "migrate: $migration_unit"
@@ -738,18 +999,23 @@ let
             migration_result=ok
           else
             migration_result=failed
-            finish_record "$record_dir" "$record_path" "$app" "$channel" "$target" migration-failed "$migration_result" "$smoke_result"
+            if restore_release_images "$record_path/desired-images.tsv" "$record_path/before-images.tsv"; then
+              result=migration-failed
+            else
+              result=migration-recovery-failed
+            fi
+            finish_record "$record_dir" "$record_path" "$app" "$channel" "$target" "$result" "$migration_result" "$smoke_result"
             return 1
           fi
         fi
 
-        while IFS= read -r service_unit; do
-          echo "restart: $service_unit"
-          if ! systemctl restart "$service_unit"; then
-            finish_record "$record_dir" "$record_path" "$app" "$channel" "$target" restart-failed "$migration_result" "$smoke_result"
-            return 1
-          fi
-        done < <(service_units "$meta")
+        mapfile -t release_service_units < <(release_units "$meta")
+        [ "''${#release_service_units[@]}" -gt 0 ] || die "metadata has no release service units"
+        echo "restart: ''${release_service_units[*]}"
+        if ! systemctl restart "''${release_service_units[@]}"; then
+          finish_record "$record_dir" "$record_path" "$app" "$channel" "$target" restart-failed "$migration_result" "$smoke_result"
+          return 1
+        fi
 
         snapshot_images "$meta" > "$record_path/after-images.tsv"
 
@@ -760,28 +1026,9 @@ let
         else
           smoke_result=failed
           finish_record "$record_dir" "$record_path" "$app" "$channel" "$target" smoke-failed "$migration_result" "$smoke_result"
-          echo "smoke failed; rollback record: $record_path" >&2
-          echo "run: sudo -n homelab-appctl rollback $app $channel" >&2
+          echo "smoke failed; deploy a known-good release target to roll back: $record_path" >&2
           return 1
         fi
-      }
-
-      cmd_rollback() {
-        local app=$1
-        local channel=$2
-        local record_dir latest
-
-        require_root rollback "$app" "$channel"
-
-        record_dir="$state_root/$app/$channel"
-        latest="$record_dir/latest"
-        [ -e "$latest" ] || die "no deploy record found for $app $channel"
-
-        echo "automatic rollback is not enabled yet for $app $channel"
-        echo "latest deploy record: $(readlink "$latest" || printf '%s' "$latest")"
-        echo "previous images:"
-        cat "$latest/before-images.tsv"
-        return 2
       }
 
       command=''${1:-}
@@ -790,7 +1037,7 @@ let
           [ "$#" -eq 1 ] || die "list takes no arguments"
           cmd_list
           ;;
-        status|smoke|logs|rollback)
+        status|smoke|logs)
           [ "$#" -eq 3 ] || {
             usage >&2
             exit 1
@@ -802,7 +1049,6 @@ let
             status) cmd_status "$meta" ;;
             smoke) cmd_smoke "$meta" ;;
             logs) cmd_logs "$meta" ;;
-            rollback) cmd_rollback "$app" "$channel" ;;
           esac
           ;;
         deploy)
@@ -832,6 +1078,7 @@ let
                 ;;
             esac
           done
+          [ -n "$target" ] || die "deploy requires --target <release-id>"
           meta=$(require_metadata "$app" "$channel")
           cmd_deploy "$app" "$channel" "$meta" "$dry_run" "$target"
           ;;
@@ -863,6 +1110,7 @@ let
       ) contract.services;
       migrationServiceIsRegistryAuto =
         migrationService != null && builtins.hasAttr migrationService registryAutoServices;
+      manualServices = filterAttrs (_: service: releaseManaged service) contract.services;
     in
     [
       {
@@ -908,6 +1156,51 @@ let
         assertion = migrationMode == "none" || !migrationServiceIsRegistryAuto;
         message = "homelab.apps.${appName}: registry-auto is not allowed on the migration service.";
       }
+      {
+        assertion = builtins.match "^[0-9a-f]{64}$" app.runtimeContractSourceSha256 != null;
+        message = "homelab.apps.${appName}: runtimeContractSourceSha256 must be a lowercase SHA-256 hex digest.";
+      }
+      {
+        assertion = builtins.match "^[0-9a-f]{64}$" app.homelabAdmissionSourceSha256 != null;
+        message = "homelab.apps.${appName}: homelabAdmissionSourceSha256 must be a lowercase SHA-256 hex digest.";
+      }
+      {
+        assertion = builtins.match "^[0-9a-f]{64}$" app.manifestSchemaSourceSha256 != null;
+        message = "homelab.apps.${appName}: manifestSchemaSourceSha256 must be a lowercase SHA-256 hex digest.";
+      }
+      {
+        assertion = builtins.match "^[0-9a-f]{64}$" app.manifestGeneratorSourceSha256 != null;
+        message = "homelab.apps.${appName}: manifestGeneratorSourceSha256 must be a lowercase SHA-256 hex digest.";
+      }
+      {
+        assertion =
+          manualServices == { } || (releaseChannelFor app != null && contract.release.manifestUrl != null);
+        message = "homelab.apps.${appName}: manual services require release channel metadata and a manifestUrl.";
+      }
+      {
+        assertion =
+          contract.release.manifestUrl == null || lib.hasInfix "{target}" contract.release.manifestUrl;
+        message = "homelab.apps.${appName}: release.manifestUrl must contain the {target} placeholder.";
+      }
+      {
+        assertion =
+          contract.release.manifestUrl == null || lib.hasPrefix "https://" contract.release.manifestUrl;
+        message = "homelab.apps.${appName}: release.manifestUrl must use HTTPS.";
+      }
+      {
+        assertion = builtins.all (
+          origin: lib.hasPrefix "https://" origin && !(lib.hasSuffix "/" origin)
+        ) app.host.releaseManifestOrigins;
+        message = "homelab.apps.${appName}: host.releaseManifestOrigins must contain HTTPS origins without a trailing slash.";
+      }
+      {
+        assertion =
+          manualServices == { }
+          || builtins.any (
+            origin: lib.hasPrefix "${origin}/" contract.release.manifestUrl
+          ) app.host.releaseManifestOrigins;
+        message = "homelab.apps.${appName}: release.manifestUrl must match a host-admitted releaseManifestOrigin.";
+      }
     ]
     ++ flatten (
       mapAttrsToList (
@@ -920,6 +1213,10 @@ let
           {
             assertion = channel.migrate != "manual" || migrationMode == "manual";
             message = "homelab.apps.${appName}: release channel ${channelName} cannot request manual migration when contract.migrations.mode is not manual.";
+          }
+          {
+            assertion = lib.hasPrefix "^" channel.targetPattern && lib.hasSuffix "$" channel.targetPattern;
+            message = "homelab.apps.${appName}: release channel ${channelName} targetPattern must be anchored with ^ and $.";
           }
         ]
         ++ map (path: {
@@ -939,6 +1236,31 @@ let
           {
             assertion = builtins.elem service.image imageNames;
             message = "homelab.apps.${appName}.${serviceName}: service.image must reference contract.images.";
+          }
+          {
+            assertion = builtins.all (
+              dependency: dependency != serviceName && builtins.elem dependency serviceNames
+            ) service.dependsOn;
+            message = "homelab.apps.${appName}.${serviceName}: dependsOn entries must reference other contract services.";
+          }
+          {
+            assertion = service.readiness == null || service.readiness.command != [ ];
+            message = "homelab.apps.${appName}.${serviceName}: readiness.command must not be empty.";
+          }
+          {
+            assertion =
+              !releaseManaged service
+              || (
+                releaseChannelFor app != null
+                && lib.hasSuffix ":${(releaseChannelFor app).tag}" (imageRefFor app service)
+              );
+            message = "homelab.apps.${appName}.${serviceName}: manual image refs must end with the admitted release channel tag.";
+          }
+          {
+            assertion =
+              service.updatePolicy != "pinned-digest"
+              || builtins.match ".*@sha256:[0-9a-f]{64}$" (imageRefFor app service) != null;
+            message = "homelab.apps.${appName}.${serviceName}: pinned-digest image refs must end with @sha256:<64 lowercase hex>.";
           }
           {
             assertion = builtins.elem "${unitPrefixFor app}-${serviceName}" (
@@ -993,6 +1315,26 @@ in
           options = {
             enable = mkEnableOption "homelab app container admission";
 
+            runtimeContractSourceSha256 = mkOption {
+              type = types.str;
+              description = "SHA-256 of the app-owned runtime contract source.";
+            };
+
+            homelabAdmissionSourceSha256 = mkOption {
+              type = types.str;
+              description = "SHA-256 of the pinned app-owned homelab admission source.";
+            };
+
+            manifestSchemaSourceSha256 = mkOption {
+              type = types.str;
+              description = "SHA-256 of the pinned app-owned release manifest schema.";
+            };
+
+            manifestGeneratorSourceSha256 = mkOption {
+              type = types.str;
+              description = "SHA-256 of the pinned app-owned release manifest generator.";
+            };
+
             contract = mkOption {
               type = types.submodule {
                 options = {
@@ -1007,6 +1349,23 @@ in
                           internalPort = mkOption { type = types.port; };
                           healthPath = mkOption {
                             type = types.nullOr types.str;
+                            default = null;
+                          };
+                          dependsOn = mkOption {
+                            type = types.listOf types.str;
+                            default = [ ];
+                          };
+                          readiness = mkOption {
+                            type = types.nullOr (
+                              types.submodule {
+                                options = {
+                                  command = mkOption { type = types.listOf types.str; };
+                                  interval = mkOption { type = types.str; };
+                                  retries = mkOption { type = types.ints.positive; };
+                                  timeout = mkOption { type = types.str; };
+                                };
+                              }
+                            );
                             default = null;
                           };
                           env = mkOption {
@@ -1083,6 +1442,10 @@ in
                           type = types.enum [ "external" ];
                           default = "external";
                         };
+                        manifestUrl = mkOption {
+                          type = types.nullOr types.str;
+                          default = null;
+                        };
                         channels = mkOption {
                           type = types.attrsOf (
                             types.submodule {
@@ -1095,6 +1458,10 @@ in
                                     "approved"
                                   ];
                                   default = "manual";
+                                };
+                                targetPattern = mkOption {
+                                  type = types.str;
+                                  description = "Anchored regular expression for release targets admitted to this channel.";
                                 };
                                 strategy = mkOption {
                                   type = types.enum [ "coordinated" ];
@@ -1110,10 +1477,6 @@ in
                                     "manual"
                                   ];
                                   default = "none";
-                                };
-                                rollback = mkOption {
-                                  type = types.enum [ "record-only" ];
-                                  default = "record-only";
                                 };
                               };
                             }
@@ -1159,6 +1522,11 @@ in
               registryAuth = mkOption {
                 type = types.nullOr types.str;
                 default = null;
+              };
+              releaseManifestOrigins = mkOption {
+                type = types.listOf types.str;
+                default = [ ];
+                description = "Host-admitted HTTPS origins allowed to serve release manifests.";
               };
               timeoutStartSec = mkOption {
                 type = types.str;
@@ -1255,9 +1623,7 @@ in
           in
           [
             (allowedCommand "${homelabAppctl}/bin/homelab-appctl deploy *")
-            (allowedCommand "${homelabAppctl}/bin/homelab-appctl rollback *")
             (allowedCommand "/run/current-system/sw/bin/homelab-appctl deploy *")
-            (allowedCommand "/run/current-system/sw/bin/homelab-appctl rollback *")
           ];
       }
     ];


### PR DESCRIPTION
## Summary

Homelab app releases now activate one immutable backend/web digest set without the previous double-restart path or an ordinary release restart of PostgreSQL. NixOS admits the app-owned contract and renders native Quadlet/systemd dependencies and readiness; one generic host transaction owns exact pull/tag, migration, release-service restart, smoke, and durable records.

The app repository still decides versions and image contents. This repository independently pins and hashes the runtime contract, homelab admission, manifest schema, and manifest generator, while retaining ownership of sops secrets, storage, routing, and activation policy.

| Decision | Result |
| --- | --- |
| Release identity | `homelab-appctl` accepts only an HTTPS manifest whose target, four source hashes, image names, and exact digests match generated admission metadata. |
| Native runtime | `dependsOn` becomes systemd `Requires`/`After`; PostgreSQL readiness becomes Quadlet health plus `Notify=healthy`. |
| Single writer | Manual backend/web containers use `Pull=never`; appctl takes a per-app/channel lock, moves local tags, migrates once, restarts backend/web together once, and smokes once. |
| Failure handling | Pre-restart failures restore prior tags, interrupted records remain retryable, and recovery failures are explicit rather than silently reported as ordinary failures. |
| Activation | Contract changes move through the input-only PR and comin path; no activation script or direct development-machine `nixos-rebuild` was added. |

## Validation

- `nix fmt` reports zero formatting changes with the app input pinned to merge `ad6a8af8`.
- `nix flake check --all-systems --no-build --show-trace` evaluates every output and the two new Linux checks without an input override.
- Generated metadata proves the four independent source hashes, HTTPS manifest origin, release-managed backend/web, and independently pinned PostgreSQL digest.
- Generated Quadlet data proves `Pull=never`, DB `Requires`/`After`, `pg_isready`, and `Notify=healthy`; generated appctl passes Bash syntax and ShellCheck.
- The deploy workflows pass actionlint. [Linux CI run 29748811056](https://github.com/rjcnd105/hj-dotfiles/actions/runs/29748811056) builds and passes the full dry-run and transaction derivations, including negative manifest cases, exact pull/tag, one migration, one combined backend/web restart, no PostgreSQL restart, smoke, retry, recovery-failure, and concurrency behavior.

## Related

Related: https://github.com/rjcnd105/my-app/pull/40

## New concepts

### Single-writer release transaction

Declarative NixOS owns the stable runtime shape, while one narrow imperative transaction owns the mutations that must happen together. Keeping pull/tag, migration, restart, smoke, and record publication behind one lock prevents independent image units and deploy scripts from racing over the same release.

```mermaid
flowchart LR
  A[Pinned app contract] --> B[NixOS admission and generated metadata]
  B --> C[comin activates runtime shape]
  D[Immutable release manifest] --> E[homelab-appctl locked transaction]
  B --> E
  E --> F[Exact tags]
  F --> G[Migration once]
  G --> H[Backend and web restart once]
  H --> I[Smoke and final record]
```

This boundary is useful when a few services share one host and need coordinated activation. It should not grow into a bespoke cluster controller; if multiple hosts or rollout strategies require continuous reconciliation, a real scheduler becomes the clearer authority.
