### PR TITLE
fix(homelab): close appctl runtime dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -438,7 +438,7 @@
             [ "$(grep -c '^podman[[:space:]]pull ' "$HOMELAB_APPCTL_TEST_LOG")" -eq 2 ]
 
             cp "$HOMELAB_APPCTL_TEST_LOG" before-noop.log
-            homelab-appctl deploy deopjib dev --target "$target"
+            PATH=/does-not-exist ${appctl}/bin/homelab-appctl deploy deopjib dev --target "$target"
             cmp before-noop.log "$HOMELAB_APPCTL_TEST_LOG"
 
             printf '%s\n' in-progress > "$latest/result"

--- a/systems/homelab/app-containers.nix
+++ b/systems/homelab/app-containers.nix
@@ -467,6 +467,7 @@ let
     runtimeInputs = [
       pkgs.coreutils
       pkgs.curl
+      pkgs.diffutils
       pkgs.findutils
       pkgs.gnugrep
       pkgs.gnused


### PR DESCRIPTION
## Summary
- add `diffutils` to the `homelab-appctl` runtime closure because `current_target` uses `cmp`
- run the same-target regression path with an empty caller `PATH` so undeclared runtime tools cannot be inherited from the builder

## Root cause
The interactive SSH environment exposed `/run/current-system/sw/bin/cmp`, while `github-runner-homelab-deploy` did not. `current_target` suppressed the missing-command error and treated every identical release as non-current, causing a full migration/restart transaction on reruns.

## Validation
- `nix fmt -- --ci flake.nix systems/homelab/app-containers.nix`
- `nix flake check --all-systems --no-build --show-trace`
- evaluated transaction calls packaged appctl with `PATH=/does-not-exist`
- evaluated appctl derivation directly depends on `diffutils-3.12.drv`

The x86_64-linux execution checks remain authoritative in GitHub Actions because the development host is aarch64-darwin.